### PR TITLE
feat : 세션, 블로그 페이지 api 연동 및 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.3.0",
+    "react-intersection-observer": "^9.15.1",
     "react-lottie-player": "^2.1.0",
     "react-pdf": "^9.1.1",
     "react-player": "^2.16.0",

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -67,41 +67,44 @@ export default function Page() {
     },
     [blog],
   )
-  const getBlog = async (newLimit: number, query: string, category: string) => {
-    const baseUrl = 'https://api.techeerzip.cloud/api/v1/blogs'
-    const params = {
-      keyword: query,
-      category: category,
-      offset: '0',
-      limit: String(newLimit),
-    }
-    // console.log('aaaaaa', inputValue)
-    const filteredParams = Object.fromEntries(
-      Object.entries(params).filter(
-        ([_, value]) => value !== null && value !== '',
-      ),
-    )
-    const queryString = new URLSearchParams(filteredParams).toString()
-    const url = `${baseUrl}?${queryString}`
+  const getBlog = useCallback(
+    async (newLimit: number, query: string, category: string) => {
+      const baseUrl = 'https://api.techeerzip.cloud/api/v1/blogs'
+      const params = {
+        keyword: query,
+        category: category,
+        offset: '0',
+        limit: String(newLimit),
+      }
+      // console.log('aaaaaa', inputValue)
+      const filteredParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([_, value]) => value !== null && value !== '',
+        ),
+      )
+      const queryString = new URLSearchParams(filteredParams).toString()
+      const url = `${baseUrl}?${queryString}`
 
-    fetch(url)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('Network response was not ok')
-        }
-        return response.json()
-      })
-      .then((data) => {
-        setBlog(data || [])
-      })
-  }
+      fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok')
+          }
+          return response.json()
+        })
+        .then((data) => {
+          setBlog(data || [])
+        })
+    },
+    [],
+  )
   useEffect(() => {
     if (activeOption == '금주의 블로그') {
       getBestBlog(3)
     } else if (activeOption == 'TECHEER' || activeOption == 'SHARED') {
       getBlog(3, inputValue, activeOption)
     }
-  }, [activeOption, inputValue])
+  }, [activeOption, inputValue, getBestBlog, getBlog])
 
   useEffect(() => {
     if (!inView) return // inView가 false면 실행 x

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,6 +10,11 @@ interface User {
   name: string
 }
 
+interface Author {
+  authorName: string
+  authorImage: string
+}
+
 interface BlogProps {
   title: string
   id: string
@@ -17,6 +22,7 @@ interface BlogProps {
   url: string
   likeCount: number
   user: User
+  author: Author
 }
 
 export default function Page() {
@@ -51,7 +57,7 @@ export default function Page() {
         }
 
         const result = await response.json()
-        setBlog(result.data)
+        setBlog(result)
         setLimit(newLimit)
         console.log(blog)
         console.log('블로그api가 성공적으로 통신되었습니다:', result.data)
@@ -86,7 +92,7 @@ export default function Page() {
         return response.json()
       })
       .then((data) => {
-        setBlog(data.data || [])
+        setBlog(data || [])
       })
   }
   useEffect(() => {
@@ -133,7 +139,8 @@ export default function Page() {
               date={blog.date}
               url={blog.url}
               likeCount={blog.likeCount}
-              name={blog.user.name}
+              name={blog.author.authorName}
+              image={blog.author.authorImage}
               onDelete={handleDeleteSession}
             />
           ))}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -69,7 +69,7 @@ export default function Page() {
       offset: '0',
       limit: String(newLimit),
     }
-    console.log('aaaaaa', inputValue)
+    // console.log('aaaaaa', inputValue)
     const filteredParams = Object.fromEntries(
       Object.entries(params).filter(
         ([_, value]) => value !== null && value !== '',

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -144,7 +144,7 @@ export default function Page() {
               onDelete={handleDeleteSession}
             />
           ))}
-          {/* <div ref={ref} /> */}
+          <div ref={ref} />
         </div>
       </div>
       <AddBtn />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,6 +3,7 @@ import TapBar from '@/components/common/TapBar'
 import AddBtn from '@/components/common/AddBtn'
 import BlogPost from '@/components/blog/BlogPost'
 import { useTapBarStore } from '@/store/tapBarStore'
+import { useInView } from 'react-intersection-observer'
 import { useCallback, useEffect, useState } from 'react'
 
 interface User {
@@ -23,6 +24,8 @@ export default function Page() {
   const [message, setMessage] = useState<string | null>(null)
   const { activeOption } = useTapBarStore()
   const [inputValue, setInputValue] = useState('')
+  const [limit, setLimit] = useState(3)
+  const [ref, inView] = useInView()
 
   const handleSearch = (query: string) => {
     sessionStorage.setItem('searchQuery', query)
@@ -33,37 +36,40 @@ export default function Page() {
     setMessage('블로그 글이 삭제되었습니다.')
     setTimeout(() => setMessage(null), 2000)
   }
-  const getBestBlog = useCallback(async () => {
-    try {
-      const response = await fetch(
-        'https://api.techeerzip.cloud/api/v1/blogs/best?offset=0&limit=10',
-        {
-          method: 'GET',
-        },
-      )
+  const getBestBlog = useCallback(
+    async (newLimit: number) => {
+      try {
+        const response = await fetch(
+          `https://api.techeerzip.cloud/api/v1/blogs/best?offset=0&limit=${newLimit}`,
+          {
+            method: 'GET',
+          },
+        )
 
-      if (!response.ok) {
-        throw new Error('세션 데이터를 업로드하는 데 실패했습니다.')
+        if (!response.ok) {
+          throw new Error('세션 데이터를 업로드하는 데 실패했습니다.')
+        }
+
+        const result = await response.json()
+        setBlog(result.data)
+        setLimit(newLimit)
+        console.log(blog)
+        console.log('블로그api가 성공적으로 통신되었습니다:', result.data)
+      } catch (err) {
+        console.error('블로그 데이터 업로드 중 오류 발생:', err)
       }
-
-      const result = await response.json()
-      setBlog(result.data)
-      console.log(blog)
-      console.log('블로그api가 성공적으로 통신되었습니다:', result.data)
-    } catch (err) {
-      console.error('블로그 데이터 업로드 중 오류 발생:', err)
-    }
-  }, [blog])
-  const getBlog = async () => {
+    },
+    [blog],
+  )
+  const getBlog = async (newLimit: number, query: string, category: string) => {
     const baseUrl = 'https://api.techeerzip.cloud/api/v1/blogs'
     const params = {
-      keyword: '',
-      category: '',
-      position: '',
-      offset: String(0),
-      limit: String(10),
+      keyword: query,
+      category: category,
+      offset: '0',
+      limit: String(newLimit),
     }
-
+    console.log('aaaaaa', inputValue)
     const filteredParams = Object.fromEntries(
       Object.entries(params).filter(
         ([_, value]) => value !== null && value !== '',
@@ -85,11 +91,21 @@ export default function Page() {
   }
   useEffect(() => {
     if (activeOption == '금주의 블로그') {
-      getBestBlog()
-    } else if (activeOption == 'Techeer' || activeOption == 'Shared') {
-      getBlog()
+      getBestBlog(3)
+    } else if (activeOption == 'TECHEER' || activeOption == 'SHARED') {
+      getBlog(3, inputValue, activeOption)
     }
-  }, [activeOption, getBestBlog])
+  }, [activeOption, inputValue])
+
+  useEffect(() => {
+    if (!inView) return // inView가 false면 실행 x
+    if (activeOption === '금주의 블로그') {
+      getBestBlog(limit + 3)
+      return
+    } else if (activeOption == 'Techeer' || activeOption == 'Shared') {
+      getBlog(limit + 3, inputValue, activeOption)
+    }
+  }, [inView, activeOption])
 
   return (
     <div className="flex justify-center h-auto min-h-screen">
@@ -104,11 +120,11 @@ export default function Page() {
           <p className="text-[1.25rem]">테커인들의 블로그를 확인해보세요.</p>
         </div>
         <TapBar
-          options={['금주의 블로그', 'Techeer', 'Shared']}
-          placeholder="블로그 제목 혹은 이름을 검색해보세요"
+          options={['금주의 블로그', 'TECHEER', 'SHARED']}
+          placeholder="블로그 제목을 검색해보세요"
           onSearch={handleSearch}
         />
-        <div className="grid grid-cols-3 gap-8 mt-8">
+        <div className="flex-col grid grid-cols-3 gap-8 mt-8">
           {blog.map((blog, index) => (
             <BlogPost
               key={index}
@@ -121,6 +137,7 @@ export default function Page() {
               onDelete={handleDeleteSession}
             />
           ))}
+          <div ref={ref} />
         </div>
       </div>
       <AddBtn />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -42,31 +42,27 @@ export default function Page() {
     setMessage('블로그 글이 삭제되었습니다.')
     setTimeout(() => setMessage(null), 2000)
   }
-  const getBestBlog = useCallback(
-    async (newLimit: number) => {
-      try {
-        const response = await fetch(
-          `https://api.techeerzip.cloud/api/v1/blogs/best?offset=0&limit=${newLimit}`,
-          {
-            method: 'GET',
-          },
-        )
+  const getBestBlog = useCallback(async (newLimit: number) => {
+    try {
+      const response = await fetch(
+        `https://api.techeerzip.cloud/api/v1/blogs/best?offset=0&limit=${newLimit}`,
+        {
+          method: 'GET',
+        },
+      )
 
-        if (!response.ok) {
-          throw new Error('세션 데이터를 업로드하는 데 실패했습니다.')
-        }
-
-        const result = await response.json()
-        setBlog(result)
-        setLimit(newLimit)
-        console.log(blog)
-        console.log('블로그api가 성공적으로 통신되었습니다:', result.data)
-      } catch (err) {
-        console.error('블로그 데이터 업로드 중 오류 발생:', err)
+      if (!response.ok) {
+        throw new Error('세션 데이터를 업로드하는 데 실패했습니다.')
       }
-    },
-    [blog],
-  )
+
+      const result = await response.json()
+      setBlog(result) // 상태 업데이트
+      setLimit(newLimit)
+      console.log('블로그api가 성공적으로 통신되었습니다:', result.data)
+    } catch (err) {
+      console.error('블로그 데이터 업로드 중 오류 발생:', err)
+    }
+  }, [])
   const getBlog = useCallback(
     async (newLimit: number, query: string, category: string) => {
       const baseUrl = 'https://api.techeerzip.cloud/api/v1/blogs'
@@ -76,7 +72,7 @@ export default function Page() {
         offset: '0',
         limit: String(newLimit),
       }
-      // console.log('aaaaaa', inputValue)
+
       const filteredParams = Object.fromEntries(
         Object.entries(params).filter(
           ([_, value]) => value !== null && value !== '',
@@ -85,26 +81,27 @@ export default function Page() {
       const queryString = new URLSearchParams(filteredParams).toString()
       const url = `${baseUrl}?${queryString}`
 
-      fetch(url)
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error('Network response was not ok')
-          }
-          return response.json()
-        })
-        .then((data) => {
-          setBlog(data || [])
-        })
+      try {
+        const response = await fetch(url)
+        if (!response.ok) {
+          throw new Error('Network response was not ok')
+        }
+        const data = await response.json()
+        setBlog(data || [])
+      } catch (err) {
+        console.error('블로그 데이터 로딩 중 오류 발생:', err)
+      }
     },
     [],
   )
+
   useEffect(() => {
     if (activeOption == '금주의 블로그') {
       getBestBlog(3)
     } else if (activeOption == 'TECHEER' || activeOption == 'SHARED') {
       getBlog(3, inputValue, activeOption)
     }
-  }, [activeOption, inputValue, getBestBlog, getBlog])
+  }, [activeOption, inputValue])
 
   useEffect(() => {
     if (!inView) return // inView가 false면 실행 x
@@ -147,7 +144,7 @@ export default function Page() {
               onDelete={handleDeleteSession}
             />
           ))}
-          <div ref={ref} />
+          {/* <div ref={ref} /> */}
         </div>
       </div>
       <AddBtn />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Dropdown from '@/components/profile/Dropdown'
 import FilterBtn from '@/components/session/FilterBtn'
-import ProfileList from './@projectList'
+// import ProfileList from './@projectList'
 
 export default function Page() {
   // const [selectedPeriods, setSelectedPeriods] = useState<string[]>([])
@@ -111,12 +111,12 @@ export default function Page() {
             />
           ))}
         </div>
-        <ProfileList
+        {/* <ProfileList
           position={selectedPosition.join(',')}
           year={selectedYear.length > 0 ? selectedYear[0] : undefined}
           university={selectedUniversity.join(',')}
           grade={selectedActive.join(',')}
-        />
+        /> */}
       </div>
     </div>
   )

--- a/src/app/session/@modal/default.tsx
+++ b/src/app/session/@modal/default.tsx
@@ -1,3 +1,3 @@
 export default function Default() {
-  return <div className="h-screen">가로챔</div>
+  return <div className="h-scree" />
 }

--- a/src/app/session/_lib/deleteSession.ts
+++ b/src/app/session/_lib/deleteSession.ts
@@ -9,9 +9,14 @@ export const deleteSession = async (id: string) => {
       credentials: 'include',
     },
   )
+  if (response.status == 403) {
+    alert('본인이 작성한 게시물만 삭제할 수 있습니다.')
+    throw new Error('세션 데이터를 삭제하는데 실패했습니다.')
+  }
   if (!response.ok) {
     throw new Error('세션 데이터를 삭제하는데 실패했습니다.')
   }
+
   const result = await response.json()
   return result.data
 }

--- a/src/app/session/_lib/getBestSessions.ts
+++ b/src/app/session/_lib/getBestSessions.ts
@@ -1,6 +1,6 @@
-export const getBestSessions = async () => {
+export const getBestSessions = async (limit: number) => {
   const response = await fetch(
-    'https://api.techeerzip.cloud/api/v1/sessions/best?offset=0&limit=10',
+    `https://api.techeerzip.cloud/api/v1/sessions/best?offset=0&limit=${limit}`,
   )
   if (!response.ok) {
     throw new Error('금주의 세션 데이터를 가져오는 데 실패했습니다.')

--- a/src/app/session/_lib/getBestSessions.ts
+++ b/src/app/session/_lib/getBestSessions.ts
@@ -6,5 +6,5 @@ export const getBestSessions = async (limit: number) => {
     throw new Error('금주의 세션 데이터를 가져오는 데 실패했습니다.')
   }
   const result = await response.json()
-  return result.data
+  return result
 }

--- a/src/app/session/_lib/getSessions.ts
+++ b/src/app/session/_lib/getSessions.ts
@@ -1,12 +1,18 @@
-export const getSessions = async (query: string, category: string) => {
+export const getSessions = async (
+  query: string,
+  category: string,
+  newLimit: number,
+  date: string = '',
+  position: string = '',
+) => {
   const baseUrl = 'https://api.techeerzip.cloud/api/v1/sessions'
   const params = {
     keyword: query,
     category,
-    date: '',
-    position: '',
+    date: date ?? '',
+    position: position ?? '',
     offset: '0',
-    limit: '10',
+    limit: String(newLimit),
   }
   const filteredParams = Object.fromEntries(
     Object.entries(params).filter(

--- a/src/app/session/_lib/getSessions.ts
+++ b/src/app/session/_lib/getSessions.ts
@@ -27,5 +27,5 @@ export const getSessions = async (
     throw new Error('세션 데이터를 가져오는 데 실패했습니다.')
   }
   const result = await response.json()
-  return result.data
+  return result
 }

--- a/src/app/session/_lib/getSingleSession.ts
+++ b/src/app/session/_lib/getSingleSession.ts
@@ -10,5 +10,5 @@ export const getSingleSession = async (id: string) => {
     throw new Error('단일 세션 데이터를 가져오는 데 실패했습니다.')
   }
   const result = await response.json()
-  return result.data
+  return result
 }

--- a/src/app/session/_lib/useSessionsQuery.ts
+++ b/src/app/session/_lib/useSessionsQuery.ts
@@ -1,0 +1,73 @@
+import { useQuery } from '@tanstack/react-query'
+import { getSessions } from '@/app/session/_lib/getSessions'
+import { getBestSessions } from '@/app/session/_lib/getBestSessions'
+
+interface UseSessionsQueryParams {
+  activeOption: string
+  inputValue: string
+  limit: number
+  selectedPeriodsP: string[]
+  selectedPeriodsB: string[]
+  selectedPeriodsPo: string[]
+}
+
+export const useSessionsQuery = ({
+  activeOption,
+  inputValue,
+  limit,
+  selectedPeriodsP,
+  selectedPeriodsB,
+  selectedPeriodsPo,
+}: UseSessionsQueryParams) => {
+  const category =
+    activeOption === '부트캠프'
+      ? 'BOOTCAMP'
+      : activeOption === '파트너스'
+        ? 'PARTNERS'
+        : activeOption === '전체보기'
+          ? ''
+          : ''
+
+  return useQuery({
+    queryKey: [
+      'sessions',
+      {
+        activeOption,
+        inputValue,
+        limit,
+        selectedPeriodsP,
+        selectedPeriodsB,
+        selectedPeriodsPo,
+        category,
+      },
+    ],
+    queryFn: async () => {
+      if (activeOption === '금주의 세션') {
+        const data = await getBestSessions(limit)
+        console.log('getBestSessions result:', data)
+        return data ?? []
+      }
+
+      let date = ''
+      if (activeOption === '부트캠프') {
+        date = selectedPeriodsB[0] ?? ''
+      } else if (activeOption === '파트너스') {
+        date = selectedPeriodsP[0] ?? ''
+      }
+      // console.log('date:', date)
+      // console.log('포지션:', selectedPeriodsPo[0] ?? '')
+      // console.log('category:', category)
+      // console.log('limit:', limit)
+      // console.log('inputValue:', inputValue)
+      const data = await getSessions(
+        inputValue,
+        category,
+        limit,
+        date,
+        selectedPeriodsPo[0] ?? '',
+      )
+      // console.log('getSessions result:', data)
+      return data ?? []
+    },
+  })
+}

--- a/src/app/session/_lib/useSessionsQuery.ts
+++ b/src/app/session/_lib/useSessionsQuery.ts
@@ -24,9 +24,7 @@ export const useSessionsQuery = ({
       ? 'BOOTCAMP'
       : activeOption === '파트너스'
         ? 'PARTNERS'
-        : activeOption === '전체보기'
-          ? ''
-          : ''
+        : ''
 
   return useQuery({
     queryKey: [

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -97,7 +97,7 @@ export default function Page() {
           <p className="text-4xl mb-5 font-bold">세션영상</p>
           <p className="text-xl">테커인들의 세션영상을 확인해보세요.</p>
         </div>
-        <div
+        <button
           onClick={() => {
             setSelectedPeriodsP([])
             setSelectedPeriodsPo([])
@@ -109,7 +109,7 @@ export default function Page() {
             placeholder="세션 제목을 검색해보세요"
             onSearch={handleSearch}
           />
-        </div>
+        </button>
         <div className="flex justify-start my-6 gap-3">
           {activeOption === '부트캠프' && (
             <>

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -97,7 +97,8 @@ export default function Page() {
           <p className="text-4xl mb-5 font-bold">세션영상</p>
           <p className="text-xl">테커인들의 세션영상을 확인해보세요.</p>
         </div>
-        <button
+        <div
+          typeof="button"
           onClick={() => {
             setSelectedPeriodsP([])
             setSelectedPeriodsPo([])
@@ -109,7 +110,7 @@ export default function Page() {
             placeholder="세션 제목을 검색해보세요"
             onSearch={handleSearch}
           />
-        </button>
+        </div>
         <div className="flex justify-start my-6 gap-3">
           {activeOption === '부트캠프' && (
             <>

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -264,21 +264,21 @@ export default function Page() {
               <FilterBtn
                 key={period}
                 title={period}
-                setSelectedPeriods={setSelectedPeriodsP}
+                onClick={() => setSelectedPeriodsP([])}
               />
             ))}
             {selectedPeriodsB.map((period) => (
               <FilterBtn
                 key={period}
                 title={period}
-                setSelectedPeriods={setSelectedPeriodsB}
+                onClick={() => setSelectedPeriodsB([])}
               />
             ))}
             {selectedPeriodsPo.map((period) => (
               <FilterBtn
                 key={period}
                 title={period}
-                setSelectedPeriods={setSelectedPeriodsPo}
+                onClick={() => setSelectedPeriodsPo([])}
               />
             ))}
           </div>

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -113,7 +113,7 @@ export default function Page() {
 
   useEffect(() => {
     if (!inView) return // inView가 false면 실행 x
-    console.log('inView   :   ', inView)
+    // console.log('inView   :   ', inView)
     if (activeOption === '금주의 세션') {
       fetchBestSession(limit + 3)
       return
@@ -283,7 +283,7 @@ export default function Page() {
             ))}
           </div>
         )}
-        <div className=" flex-col grid grid-cols-3 gap-8">
+        <div className="flex-col grid grid-cols-3 gap-8">
           {sessions?.map((data: any) => (
             <SessionPost
               key={data.id}

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -40,15 +40,15 @@ export default function BlogPost({
   return (
     <div className="flex">
       <div className="flex flex-col w-[379px] relative ">
-        <img
-          src={image}
-          alt="testIMG"
-          // unoptimized
-          width={379}
-          height={199}
-          className="w-[379px] h-[199px] z-1"
-          onClick={handleClickUrl}
-        />
+        <button onClick={handleClickUrl}>
+          <img
+            src={image}
+            alt="testIMG"
+            width={379}
+            height={199}
+            className="w-[379px] h-[199px] z-1"
+          />
+        </button>
         <div className="rounded-b-lg w-[379px] min-h-[100px] h-auto py-2  bg-white shadow-[0px_5px_8px_#bfbfbf]">
           <div className="flex justify-between relative">
             <p className="text-base mx-5 mb-1 truncate">{title}</p>

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -11,6 +11,7 @@ export interface BlogPostProps {
   id: string
   url: string
   likeCount: number
+  image: string
   onDelete: (id: string) => void
 }
 
@@ -21,6 +22,7 @@ export default function BlogPost({
   id,
   likeCount,
   url,
+  image,
   onDelete,
 }: BlogPostProps) {
   const [showModal, setShowModal] = useState(false)
@@ -38,10 +40,10 @@ export default function BlogPost({
   return (
     <div className="flex">
       <div className="flex flex-col w-[379px] relative ">
-        <Image
-          src="/images/win.png"
+        <img
+          src={image}
           alt="testIMG"
-          unoptimized
+          // unoptimized
           width={379}
           height={199}
           className="w-[379px] h-[199px] z-1"

--- a/src/components/session/EditSession.tsx
+++ b/src/components/session/EditSession.tsx
@@ -137,7 +137,7 @@ export default function EditSession() {
 
   useEffect(() => {
     fetchSignleSession()
-  }, [sessionId])
+  }, [sessionId, fetchSignleSession])
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/components/session/EditSession.tsx
+++ b/src/components/session/EditSession.tsx
@@ -69,6 +69,10 @@ export default function EditSession() {
         },
       )
       router.push('/session')
+      if (response.status == 403) {
+        alert('본인이 작성한 게시물만 수정할 수 있습니다.')
+        throw new Error('세션 데이터를 수정하는 데 실패했습니다.')
+      }
       if (!response.ok) {
         throw new Error('세션 데이터를 수정하는 데 실패했습니다.')
       }
@@ -202,22 +206,22 @@ export default function EditSession() {
           </p>
           <div className="flex gap-3 mt-1 mb-2">
             <CategoryBtn
-              title="Frontend"
+              title="FRONTEND"
               isSelected={selectedCategory === 'FRONTEND'}
               onSelect={() => handlePositionChange('FRONTEND')}
             />
             <CategoryBtn
-              title="Backend"
+              title="BACKEND"
               isSelected={selectedCategory === 'BACKEND'}
               onSelect={() => handlePositionChange('BACKEND')}
             />
             <CategoryBtn
-              title="DevOps"
+              title="DEVOPS"
               isSelected={selectedCategory === 'DEVOPS'}
               onSelect={() => handlePositionChange('DEVOPS')}
             />
             <CategoryBtn
-              title="Others"
+              title="OTHERS"
               isSelected={selectedCategory === 'OTHERS'}
               onSelect={() => handlePositionChange('OTHERS')}
             />

--- a/src/components/session/EditSession.tsx
+++ b/src/components/session/EditSession.tsx
@@ -2,87 +2,129 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useParams, useRouter } from 'next/navigation'
-import ModalInputField from '@/components/common/ModalInputField'
+import { useParams } from 'next/navigation'
+import { useMutation } from '@tanstack/react-query'
 import CategoryBtn from '@/components/session/CategoryBtn'
+import ModalInputField from '@/components/common/ModalInputField'
 import SessionDropdown from '@/components/session/SessionDropdown'
-import Link from 'next/link'
 import { getSingleSession } from '@/app/session/_lib/getSingleSession'
+
+interface SessionFormData {
+  thumbnail: string
+  title: string
+  presenter: string
+  date: string
+  position: string
+  category: string
+  videoUrl: string
+  fileUrl: string
+}
+
+const updateSession = async (data: {
+  id: string
+  payload: SessionFormData
+}) => {
+  const response = await fetch(
+    `https://api.techeerzip.cloud/api/v1/sessions/${data.id}`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(data.payload),
+    },
+  )
+
+  if (response.status === 403) {
+    throw new Error('본인이 작성한 게시물만 수정할 수 있습니다.')
+  }
+  if (!response.ok) {
+    throw new Error('세션 데이터를 수정하는 데 실패했습니다.')
+  }
+
+  return response.json()
+}
+
+const DEBOUNCE_DELAY = 1000
+const BOOTCAMP_OPTIONS = {
+  titles: [
+    '2022년 여름',
+    '2022년 겨울',
+    '2023년 여름',
+    '2023년 겨울',
+    '2024년 여름',
+  ],
+  values: [
+    'SUMMER_2022',
+    'WINTER_2022',
+    'SUMMER_2023',
+    'WINTER_2023',
+    'SUMMER_2024',
+  ],
+}
+const PARTNERS_OPTIONS = {
+  titles: ['1기', '2기', '3기', '4기', '5기', '6기', '7기', '8기'],
+  values: [
+    'FIRST',
+    'SECOND',
+    'THIRD',
+    'FOURTH',
+    'FIFTH',
+    'SIXTH',
+    'SEVENTH',
+    'EIGHTH',
+  ],
+}
+const CATEGORIES = ['FRONTEND', 'BACKEND', 'DEVOPS', 'OTHERS']
+
+const initialFormData: SessionFormData = {
+  thumbnail: '',
+  title: '',
+  presenter: '',
+  date: '',
+  position: '',
+  category: '',
+  videoUrl: '',
+  fileUrl: '',
+}
 
 export default function EditSession() {
   const params = useParams()
-  const router = useRouter()
   const sessionId = params.id as string
-  const [formData, setFormData] = useState({
-    thumbnail: '',
-    title: '',
-    presenter: '',
-    date: '',
-    position: '',
-    category: '',
-    videoUrl: '',
-    fileUrl: '',
-  })
+  const [debouncedThumbnail, setDebouncedThumbnail] = useState('')
+  const [thumbnailError, setThumbnailError] = useState(false)
+  const [formData, setFormData] = useState<SessionFormData>(initialFormData)
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+
+  const { mutate } = useMutation({
+    mutationFn: updateSession,
+    onSuccess: () => {
+      console.log('세션이 성공적으로 수정되었습니다')
+      window.location.href = '/session'
+    },
+    onError: (error: Error) => {
+      console.error('세션 데이터 수정 중 오류 발생:', error)
+      if (error.message.includes('본인이 작성한 게시물')) {
+        alert('본인이 작성한 게시물만 수정할 수 있습니다.')
+      }
+    },
+  })
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    setFormData({
-      ...formData,
-      [name]: value,
-    })
+    setFormData((prev) => ({ ...prev, [name]: value }))
   }
+
   const handlePositionChange = (category: string) => {
     setSelectedCategory(category)
-    setFormData({
-      ...formData,
-      position: category,
-    })
+    setFormData((prev) => ({ ...prev, position: category }))
   }
-  const handleDropdownChange = (value: string) => {
-    setFormData({
-      ...formData,
-      date: value,
-    })
-  }
-  const patchSession = async () => {
-    try {
-      const payload = {
-        thumbnail: formData.thumbnail,
-        title: formData.title,
-        presenter: formData.presenter,
-        date: formData.date,
-        position: formData.position,
-        category: formData.category,
-        videoUrl: formData.videoUrl,
-        fileUrl: formData.fileUrl,
-      }
 
-      const response = await fetch(
-        `https://api.techeerzip.cloud/api/v1/sessions/${sessionId}`,
-        {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify(payload),
-        },
-      )
-      router.push('/session')
-      if (response.status == 403) {
-        alert('본인이 작성한 게시물만 수정할 수 있습니다.')
-        throw new Error('세션 데이터를 수정하는 데 실패했습니다.')
-      }
-      if (!response.ok) {
-        throw new Error('세션 데이터를 수정하는 데 실패했습니다.')
-      }
-      const result = await response.json()
-      console.log('세션이 성공적으로 수정되었습니다:', result)
-      // onClose()
-    } catch (err) {
-      console.error('세션 데이터 수정 중 오류 발생:', err)
-    }
+  const handleDropdownChange = (value: string) => {
+    setFormData((prev) => ({ ...prev, date: value }))
   }
+
   const fetchSignleSession = async () => {
     try {
       const singleVideo = await getSingleSession(sessionId)
@@ -92,22 +134,42 @@ export default function EditSession() {
       console.error('세션 데이터 가져오기 실패:', err)
     }
   }
-  const [debouncedThumbnail, setDebouncedThumbnail] = useState(
-    formData.thumbnail,
-  )
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedThumbnail(formData.thumbnail)
-    }, 1000)
-
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [formData.thumbnail])
 
   useEffect(() => {
     fetchSignleSession()
-  }, [])
+  }, [sessionId])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedThumbnail(formData.thumbnail)
+    }, DEBOUNCE_DELAY)
+    return () => clearTimeout(timer)
+  }, [formData.thumbnail])
+
+  const renderDateDropdown = () => {
+    if (formData.category === 'PARTNERS') {
+      return (
+        <SessionDropdown
+          titles={PARTNERS_OPTIONS.titles}
+          options={PARTNERS_OPTIONS.values}
+          selectedOption={formData.date}
+          onSelect={handleDropdownChange}
+        />
+      )
+    }
+    if (formData.category === 'BOOTCAMP') {
+      return (
+        <SessionDropdown
+          titles={BOOTCAMP_OPTIONS.titles}
+          options={BOOTCAMP_OPTIONS.values}
+          selectedOption={formData.date}
+          onSelect={handleDropdownChange}
+        />
+      )
+    }
+    return null
+  }
+
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-black/50 fixed inset-0">
       <div className="w-[486px] min-h-[750px] h-auto flex flex-col items-center bg-white rounded-lg">
@@ -115,17 +177,20 @@ export default function EditSession() {
           <p className="text-2xl text-center mt-6 mb-3 font-semibold">
             세션 영상 수정
           </p>
-          <div className="mt-2 relative ">
+          <div className="mt-2 relative">
             <img
-              src={debouncedThumbnail}
+              src={
+                thumbnailError
+                  ? '/images/session/thumbnail.png'
+                  : debouncedThumbnail
+              }
               alt="PDF First Page Preview"
               className="object-cover w-[230px] h-[140px]"
-              onError={(e: any) => {
-                e.target.src = '/images/session/thumbnail.png'
-              }}
+              onError={() => setThumbnailError(true)}
             />
           </div>
         </div>
+
         <div className="flex flex-col relative mx-8 mt-4">
           <ModalInputField
             title="세션 제목을 입력해주세요"
@@ -150,82 +215,28 @@ export default function EditSession() {
               handleInputChange={handleInputChange}
             />
           </div>
+
           <div className="flex justify-between mt-1 mb-2 items-start">
             <span>
               기간을 입력해주세요 <span className="text-primary">*</span>
             </span>
-            {formData.category === 'PARTNERS' && (
-              <SessionDropdown
-                titles={[
-                  '1기',
-                  '2기',
-                  '3기',
-                  '4기',
-                  '5기',
-                  '6기',
-                  '7기',
-                  '8기',
-                ]}
-                options={[
-                  'FIRST',
-                  'SECOND',
-                  'THIRD',
-                  'FOURTH',
-                  'FIFTH',
-                  'SIXTH',
-                  'SEVENTH',
-                  'EIGHTH',
-                ]}
-                selectedOption={formData.date}
-                onSelect={handleDropdownChange}
-              />
-            )}
-            {formData.category === 'BOOTCAMP' && (
-              <SessionDropdown
-                titles={[
-                  '2022년 여름',
-                  '2022년 겨울',
-                  '2023년 여름',
-                  '2023년 겨울',
-                  '2024년 여름',
-                ]}
-                options={[
-                  'SUMMER_2022',
-                  'WINTER_2022',
-                  'SUMMER_2023',
-                  'WINTER_2023',
-                  'SUMMER_2024',
-                ]}
-                selectedOption={formData.date}
-                onSelect={handleDropdownChange}
-              />
-            )}
+            {renderDateDropdown()}
           </div>
+
           <p>
             카테고리를 선택해주세요 <span className="text-primary">*</span>
           </p>
           <div className="flex gap-3 mt-1 mb-2">
-            <CategoryBtn
-              title="FRONTEND"
-              isSelected={selectedCategory === 'FRONTEND'}
-              onSelect={() => handlePositionChange('FRONTEND')}
-            />
-            <CategoryBtn
-              title="BACKEND"
-              isSelected={selectedCategory === 'BACKEND'}
-              onSelect={() => handlePositionChange('BACKEND')}
-            />
-            <CategoryBtn
-              title="DEVOPS"
-              isSelected={selectedCategory === 'DEVOPS'}
-              onSelect={() => handlePositionChange('DEVOPS')}
-            />
-            <CategoryBtn
-              title="OTHERS"
-              isSelected={selectedCategory === 'OTHERS'}
-              onSelect={() => handlePositionChange('OTHERS')}
-            />
+            {CATEGORIES.map((category) => (
+              <CategoryBtn
+                key={category}
+                title={category}
+                isSelected={selectedCategory === category}
+                onSelect={() => handlePositionChange(category)}
+              />
+            ))}
           </div>
+
           <ModalInputField
             title="영상 링크를 첨부해 주세요"
             placeholder="www.세션 제목.com"
@@ -241,16 +252,17 @@ export default function EditSession() {
             handleInputChange={handleInputChange}
           />
         </div>
+
         <div className="flex gap-4 mt-1">
-          <Link
-            href="/session"
+          <button
+            onClick={() => (window.location.href = '/session')}
             className="flex items-center justify-center w-[202px] rounded-md text-sm h-[34px] bg-white text-gray border border-lightgray"
           >
             취소
-          </Link>
+          </button>
           <button
             type="button"
-            onClick={patchSession}
+            onClick={() => mutate({ id: sessionId, payload: formData })}
             className="w-[202px] rounded-md text-sm h-[34px] bg-primary text-white"
           >
             등록

--- a/src/components/session/FilterBtn.tsx
+++ b/src/components/session/FilterBtn.tsx
@@ -1,21 +1,16 @@
-'use client'
 import Image from 'next/image'
-import { Dispatch, SetStateAction } from 'react'
 
 export interface FilterBtnProps {
   title: string
-  setSelectedPeriods: Dispatch<SetStateAction<string[]>>
+  onClick: () => void
 }
 
 export default function FilterBtn({
   title,
-  setSelectedPeriods,
-}: FilterBtnProps) {
+  onClick,
+}: Readonly<FilterBtnProps>) {
   return (
-    <button
-      onClick={onClick}
-      className="relative w-[10.438rem] flex items-center justify-center rounded-2xl text-lg h-9 border bg-[#FFF6F0] text-[#DD7E3A] border-primary"
-    >
+    <button className="relative w-[10.438rem] flex items-center justify-center rounded-2xl text-lg h-9 border bg-[#FFF6F0] text-[#DD7E3A] border-primary">
       {title}
       <Image
         src="/images/session/delete.png"
@@ -23,7 +18,7 @@ export default function FilterBtn({
         width={9}
         height={9}
         className="absolute right-2"
-        onClick={() => setSelectedPeriods([])}
+        onClick={onClick}
       />
     </button>
   )

--- a/src/components/session/FilterBtn.tsx
+++ b/src/components/session/FilterBtn.tsx
@@ -1,10 +1,16 @@
+'use client'
 import Image from 'next/image'
+import { Dispatch, SetStateAction } from 'react'
 
 export interface FilterBtnProps {
   title: string
+  setSelectedPeriods: Dispatch<SetStateAction<string[]>>
 }
 
-export default function FilterBtn({ title }: FilterBtnProps) {
+export default function FilterBtn({
+  title,
+  setSelectedPeriods,
+}: FilterBtnProps) {
   return (
     <div className="relative w-[167px] flex items-center justify-center rounded-2xl text-lg h-9 border bg-[#FFF6F0] text-[#DD7E3A] border-primary">
       {title}
@@ -14,6 +20,7 @@ export default function FilterBtn({ title }: FilterBtnProps) {
         width={9}
         height={9}
         className="absolute right-2"
+        onClick={() => setSelectedPeriods([])}
       />
     </div>
   )

--- a/src/components/session/SessionMenu.tsx
+++ b/src/components/session/SessionMenu.tsx
@@ -1,58 +1,33 @@
 'use client'
 
+import Link from 'next/link'
 import { TbEdit } from 'react-icons/tb'
 import { MdDeleteOutline } from 'react-icons/md'
 import { MdBookmarkBorder } from 'react-icons/md'
 import { LiaDownloadSolid } from 'react-icons/lia'
-import { deleteSession } from '@/app/session/_lib/deleteSession'
 import { useMutation } from '@tanstack/react-query'
+import { deleteSession } from '@/app/session/_lib/deleteSession'
+
 interface SessionMenuProps {
   id: string
-  onDelete: (id: string) => void
-  title: string
-  date: string
-  presenter: string
-  thumbnail: string
-  videoUrl: string
   fileUrl: string
+  showMessage: () => void
 }
 
 export default function SessionMenu({
   id,
-  onDelete,
   fileUrl,
-  title,
-  date,
-  presenter,
-  thumbnail,
-  videoUrl,
+  showMessage,
 }: SessionMenuProps) {
-  const { mutateAsync } = useMutation({ mutationFn: deleteSession })
-  const fetchDeleteSession = async () => {
-    try {
-      await mutateAsync(id)
-      onDelete(id)
-    } catch (err) {
-      console.error('세션 데이터 삭제 실패:', err)
-    }
-  }
-  const goToEditPage = () => {
-    const sessionValuses = {
-      title: title,
-      date: date,
-      presenter: presenter,
-      thumbnail: thumbnail,
-      videoUrl: videoUrl,
-      fileUrl: fileUrl,
-    }
-    sessionStorage.setItem('sessionValuses', JSON.stringify(sessionValuses))
-    window.location.href = `/session/edit/${id}`
-  }
-  // window.location.href = `/session/edit/${id}`
-
-  const handleDownload = () => {
-    window.open(fileUrl)
-  }
+  const { mutate } = useMutation({
+    mutationFn: (id: string) => deleteSession(id),
+    onSuccess: () => {
+      showMessage()
+    },
+    onError: (error) => {
+      console.error('세션 데이터 삭제 실패:', error)
+    },
+  })
   return (
     <div className="absolute right-1 top-6 flex flex-col item-center justify-center w-[100px] text-sm h-auto border bg-white border-lightgray rounded-md">
       <button
@@ -62,16 +37,15 @@ export default function SessionMenu({
         <MdBookmarkBorder className="w-4 h-4" />
         북마크
       </button>
-      <button
-        type="button"
-        onClick={goToEditPage}
+      <Link
+        href={`/session/edit/${id}`}
         className="flex items-center justify-start gap-1 pl-3 py-1 hover:bg-black/10"
       >
         <TbEdit className="w-4 h-4" />
         수정
-      </button>
+      </Link>
       <button
-        onClick={handleDownload}
+        onClick={() => window.open(fileUrl)}
         className="flex items-center justify-start gap-1 pl-3 py-1 hover:bg-black/10"
       >
         <LiaDownloadSolid className="w-4 h-4" />
@@ -80,7 +54,7 @@ export default function SessionMenu({
       <button
         type="button"
         className="flex items-center justify-start gap-1 pl-3 py-1 hover:bg-black/10"
-        onClick={fetchDeleteSession}
+        onClick={() => mutate(id)}
       >
         <MdDeleteOutline className="w-4 h-4" />
         삭제

--- a/src/components/session/SessionPost.tsx
+++ b/src/components/session/SessionPost.tsx
@@ -3,19 +3,17 @@
 import Image from 'next/image'
 import { useState } from 'react'
 import SessionMenu from './SessionMenu'
-import ReactPlayer from 'react-player'
 import { useRouter } from 'next/navigation'
 
 export interface SessionPostProps {
   id: string
-  onDelete: (id: string) => void
   thumbnail: string
   readonly likeCount: number
   readonly title: string
   readonly date: string
   readonly presenter: string
-  videoUrl: string
   fileUrl: string
+  showMessage: () => void
 }
 
 export default function SessionPost({
@@ -24,18 +22,16 @@ export default function SessionPost({
   presenter,
   id,
   likeCount,
-  onDelete,
   thumbnail,
-  videoUrl,
   fileUrl,
+  showMessage,
 }: SessionPostProps) {
-  const [showModal, setShowModal] = useState(false)
-  const [isLike, setIsLike] = useState(false)
-  const [isVideo, setIsVideo] = useState(false)
   const router = useRouter()
+  const [isLike, setIsLike] = useState(false)
+  const [showModal, setShowModal] = useState(false)
   return (
     <div className="flex transition-transform transform hover:-translate-y-2">
-      <div className="flex flex-col w-[379px] relative ">
+      <div className="flex flex-col w-[379px] relative">
         <Image
           src={thumbnail}
           alt="testIMG"
@@ -64,13 +60,8 @@ export default function SessionPost({
               <div className="absolute top-[-5%] right-0 z-10">
                 <SessionMenu
                   id={id}
-                  onDelete={onDelete}
-                  title={title}
-                  date={date}
-                  presenter={presenter}
-                  thumbnail={thumbnail}
-                  videoUrl={videoUrl}
                   fileUrl={fileUrl}
+                  showMessage={showMessage}
                 />
               </div>
             )}
@@ -111,23 +102,6 @@ export default function SessionPost({
           </div>
         </div>
       </div>
-      {isVideo && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className=" rounded-lg p-4 relative w-1/2">
-            <button
-              onClick={() => {
-                setIsVideo(!isVideo)
-              }}
-              className="absolute top-6 right-6 z-40 text-gray-500 w-7 h-7 flex justify-center items-center text-white rounded-full bg-black/60 hover:text-white/70"
-            >
-              ✕
-            </button>
-            <div className="video-wrapper">
-              <ReactPlayer url={videoUrl} controls width="100%" heigh="100%" />
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/session/SessionPost.tsx
+++ b/src/components/session/SessionPost.tsx
@@ -32,17 +32,20 @@ export default function SessionPost({
   return (
     <div className="flex transition-transform transform hover:-translate-y-2">
       <div className="flex flex-col w-[379px] relative">
-        <Image
-          src={thumbnail}
-          alt="testIMG"
-          unoptimized
-          width={379}
-          height={199}
-          className="w-[379px] h-[199px] z-1"
+        <button
           onClick={() => {
             router.push(`/session/video/${id}`)
           }}
-        />
+        >
+          <Image
+            src={thumbnail}
+            alt="testIMG"
+            unoptimized
+            width={379}
+            height={199}
+            className="w-[379px] h-[199px] z-1"
+          />
+        </button>
         <div className="rounded-b-lg w-[379px] min-h-[100px] h-auto py-2  bg-white shadow-[0px_5px_8px_#bfbfbf]">
           <div className="flex justify-between relative">
             <p className="text-base mx-5 mb-1 truncate">{title}</p>

--- a/src/components/session/ShowVideo.tsx
+++ b/src/components/session/ShowVideo.tsx
@@ -17,22 +17,22 @@ export default function ShowVideo() {
   const onClickBack = () => {
     router.back()
   }
-  const fetchSignleSession = async () => {
-    if (!sessionId) {
-      console.error('Session ID is missing!')
-      return
-    }
-    try {
-      const singleVideo = await getSingleSession(sessionId)
-      setSession(singleVideo)
-    } catch (err) {
-      console.error('세션 데이터 가져오기 실패:', err)
-    }
-  }
   useEffect(() => {
+    const fetchSignleSession = async (sessionId: string) => {
+      if (!sessionId) {
+        console.error('Session ID is missing!')
+        return
+      }
+      try {
+        const singleVideo = await getSingleSession(sessionId)
+        setSession(singleVideo)
+      } catch (err) {
+        console.error('세션 데이터 가져오기 실패:', err)
+      }
+    }
     console.log('Session ID:', sessionId)
-    fetchSignleSession()
-  }, [])
+    fetchSignleSession(sessionId)
+  }, [sessionId])
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">

--- a/src/store/tapBarStore.ts
+++ b/src/store/tapBarStore.ts
@@ -6,7 +6,7 @@ interface TapBarState {
 }
 
 export const useTapBarStore = create<TapBarState>((set) => ({
-  activeOption: null,
+  activeOption: '',
   setActiveOption: (option) => {
     set({ activeOption: option })
   },

--- a/src/store/tapBarStore.ts
+++ b/src/store/tapBarStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 
 interface TapBarState {
   activeOption: string | null
@@ -8,7 +8,6 @@ interface TapBarState {
 export const useTapBarStore = create<TapBarState>((set) => ({
   activeOption: null,
   setActiveOption: (option) => {
-    // console.log('쥬스탠드가 보관! - ', option) // 상태 변경 시 콘솔에 출력
     set({ activeOption: option })
   },
 }))

--- a/src/store/tapBarStore.ts
+++ b/src/store/tapBarStore.ts
@@ -8,7 +8,7 @@ interface TapBarState {
 export const useTapBarStore = create<TapBarState>((set) => ({
   activeOption: null,
   setActiveOption: (option) => {
-    console.log('쥬스탠드가 보관! - ', option) // 상태 변경 시 콘솔에 출력
+    // console.log('쥬스탠드가 보관! - ', option) // 상태 변경 시 콘솔에 출력
     set({ activeOption: option })
   },
 }))

--- a/src/stories/blog/BlogPost.stories.tsx
+++ b/src/stories/blog/BlogPost.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
 } satisfies Meta<typeof BlogPost>
 
 export default meta
+
 type Story = StoryObj<typeof meta>
 const onDelete = (id: string) => {
   console.log(`Deleted post with id: ${id}`)
@@ -23,6 +24,7 @@ export const Default: Story = {
     id: '2',
     likeCount: 0,
     url: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+    image: '/images/default-thumbnail.png',
     onDelete: onDelete,
   },
 }
@@ -36,6 +38,7 @@ export const LongTitle: Story = {
     id: '2',
     likeCount: 0,
     url: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+    image: '/images/default-thumbnail.png',
     onDelete: onDelete,
   },
 }

--- a/src/stories/session/SessionPost.stories.tsx
+++ b/src/stories/session/SessionPost.stories.tsx
@@ -1,5 +1,6 @@
 import SessionPost from '@/components/session/SessionPost'
 import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
 
 const meta = {
   title: 'Session/SessionPost',
@@ -12,23 +13,20 @@ const meta = {
 
 export default meta
 type Story = StoryObj<typeof meta>
-const onDelete = (id: string) => {
-  console.log(`Deleted post with id: ${id}`)
-}
 export const Default: Story = {
   args: {
     title: '동계 부트캠프 회고록',
     date: '2024년 8월',
+    likeCount: 0,
     presenter: '김아파트',
     id: '2',
-    likeCount: 0,
+    showMessage: () => {
+      console.log('삭제되었습니다.')
+    },
     thumbnail:
       'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQDw8PEBIPDw8NDQ0NDw8PDQ8NDw0NFREWFhURFRUYHSggGBolGxUVITEhJSkrLi4uFx8zODMtNygtLisBCgoKDg0NFQ8PFS0ZFRkrLTcrKysrLSsrNy0rNysrKzctLSstKy0tLTcrKysrLSstLSstLSsrKysrKysrKysrK//AABEIAKgBLAMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAAAQIDBAUGB//EADUQAAIBAwEGBAUDAwUBAAAAAAABAgMREgQFEyExUWFBcYGRIjJSobGSwdEUYuFCcqLw8Qb/xAAYAQEBAQEBAAAAAAAAAAAAAAAAAQIEA//EABkRAQEBAQEBAAAAAAAAAAAAAAARARICIf/aAAwDAQACEQMRAD8A+QWCxZiGJ1x4VCwWJ2HiBXYLFlgsUQsOxOwWAhYLE7DxCIWCxZiGJRXYTRbiDiBWkPEniPECvEMS3ELAUTRAvnEhgTVzUUhWLFEngCqLBiXYCcRCqrAoluIKJIVXiCiX4hiWJVWAYluINFgpaCxNxI4EEbCJYCxIqNgxJWCxFRxFiWNBYQXYhiW4hiaZVYhiW4jwKKcQxLsR4AU4jxLsQwAqxDEuwHgEUqAYl2BJQKKMR4l+AOIFGImTabLIUwKlEeBowDADM6ZF0zXgG7AxqIONuJqdIW5EGdeQYGjdDVMDLux7s04CwEGfEMDSoBgBmxE4mhwE4AZhMucCLgRVLiKyLXAjgRUMR2JpE4oCmwrGgeKCLcQwL8AwKijAeBfgPACjAeBoVMkqZSs2A1A0YBYJWfAeBowHgBnwHgaMBqmBnwIuma92SVMDJGkTVM04BgVGfAMDRgGAGfAMC/AMAqjAMC/AMAM+AYGnAWAGbAMDVgLADLgJwNbgLAgyboTomvdhuwVjdEi6ZtcBYAYXSI7vsb3Ai6aItYnSIumzcokXEFYt2PE07sN2gtaMBqBcoklErKjAlgXKA8AKcSuUrF1SDZGOnZBTe5JQNMNOXRogZI02WKmalSJbsoyqmSVM0qA8QM+7Huy7JeHH8EJ1ox5u7+lE6XPOo7kzaiduC5+5ZUrSny4LoghRM7ut55zGRVJ/9RaqvVexdUpKKu7R83Z+xy62rt/pbXW6QzdNzG3+pj0f2F/Vw/u9jmf18fof6rfsD2tb5YQXd3ky3U5x2Kc1LkpfpHWqQgvjkov6ecn6I8/W2rVl/qaXSNo/gxuo2OjnHqdPqadT5Xx+l8GX4HkIzOno9sTjwl8ce/Nepek3y7mAYEdLrqVTk7S+mXB+nU2bsrEZMAwNWAbsUZHAFTNe7E6YoyOAt2a8BYBWVwI7s1OAsQMm7FuzU4CcQM2AsDQ4iwAkoklE4lXWybvk12jeKQpTlJ5OTbXJ35eXQz03y76gTUDmabaMlwmsl1VlL/JshtKHSX25FrPOtKpjVIVPV027KSv3uvyalEVIo3Y1AsnOMebS/PsZquuiuSv5irNXKBCrUjHm0vyYKuqqS4Lgu3AjT0M5dTPTXK6prvCK9WVOq3zu+3gb6Ox3zlwXfgWulRh45PsStRzlGcuHJdjRR2e+f3ZOptCMflSXd8Tn6naEpc236gb5unDm7vpH+TJW2lb5Uo9/H3ObOsZqlQC3U6hy5swyqNcnYnKRVIgUql+aXmuBBxXg/cbREtIjKJWy5MHFPsBTcakSlTaK2gq6NQ6Gj2vUp2V8l9MviXp0OTceQqR7DSbcpTsp3pv9Ufc6kLSV4tSXVNNHz1TNGm1s6bvGTi+zsa6Z3y93gGB5/R//AEslwqRUu6+GX8M7Wk2lRq/LNJ/TL4X/AJ9C1mLMBOBqcCMopc+HnwFRlcCLgaHa7V1dc1dXXmYtRtCnHhdya8Iq/wB+QpE3ATgZJ7Xp24KTfSyX3MNfatSStFKHdfE/clXnXXaRnqaulF2c4p+dzz1RuTu22+rd2QxJ01wV2TpzsaKWzaj52j5u7+xrpbLj43l/xQaZozuWU6E3yVvPgdOhobfLFLyXH3NlLZ0n4EVyIaPq/b+TVS0yXJevNnZp7PS5tL7lmNOPhfzCOXT0cmbaWyvqsvMnU2go8FZeXA5+o2k34gdPCjT/ALmUVtqqPCKS/JxKmqbM1Sr1YHR1G0pS5syT1LZilVFk32AunU7lEqq8OIlTbJqiBS22RaNO6E6YGVog0a9yyS0kn4EGBojY6T0DXOy8yL0q7vyVkIrnWCxtenfRL1JR0bAxxQpU0+z+zOlDZ8n4Mq1+nUIWbWd1ZJptd30KjmzotFTiXxqteRP4ZdgVkC5fOiVOBFJMsjUKrBcDq6Xa1WCspyt0vdLy6FtTWyqfPOUuN7Sk2r9lyRx4yLIzNVmN9So1yv59Q39+f/pmhWLVOL5r1XAFTVVA2R3d+Tv9iEotc+Ai1Y2Qc0RcvArJFe9hs9Lm0i6NCnHuZJ6oonqWEdTexXJIqqa3ucuVVsrdwN1TWmSpqWypkHBgRq1TLKqanQuNaRgYOLHuTrU9D2NVPZ4HChpW/A0U9Gz0FLZ3Y2U9AkB5uGhfQuhs2T8D0WFOPO35ZzNqbdp0Phis6nhHkl3YGVbIdryailzbaSRjqz08OCbqP+xfD7v9jmazadWs71JXXhFcIR8kZ94WI6ktel8tOK825fwUVNfN+Nv9qSMLqi3hRfKtfm37lUpEHMi5AOTK2yTZEgg2QbLGQaIqDETaI2AlGo0TumVAmBOVIqlAsUiWSYGZoEzQ4IrlTIqKkWRmV4gUaIzLYVzGmSUi1I2fC+NrPt/Atz0at3ujPGRNTKj1iptklRNFwuZVRuh7kvSuWKlLpbz4AZNwTjpzWopc2vTiJ14Lq/ZAVw0pop6TsZ57SS5JL7lEtdOXLJ/ZAddUoR+ZxXrxIy1tGHWT9kcWTl4tR7c2OGnb44t/3TeKA6M9tN8IRXtcpepqzdnJ/wC1FElGEcpySiunwx8r+Jx9obZck4UvghybXCUv4A1bV2vu706bvPlKXNQ9fFnnm222+LfFt8W2AFDGQuLIVE7gQchZASFcWQXALiuDYmFNsVxXFcgmJoQXATQrE7iAgMbQrACY8hAAEWiTEBGwWGAUJkrkQCOvHaVX637Jl9Pa9ZeMX504P9jkKRJSKjuR29V8cH6Nfhli203zj7SOCpklMDvx2jB8815WZbCvp3zlP1T/AGPOqoWRqD4fXpYVdP4TivOM2/uib1Gn8al+3xJeyR5pVCSmhCu9PaVCPyv9FN395GDU7Zb+SPH6qjyfsYeAYoQrPXqzm7zbk+/h5dCrE1uKISigMzRBl8kQcQqlibJyiQaIFcVwZECVwuQC4VO4XIXC4RK4EbiuBK47kLhcCdwuRuAE7hchcLhUwZG4XCGyIxAILgxBUgIgQXXGmV3GmVFiY7ldxpgWXHkQTGBZmPMqBMC5VCW8KLiyA0bwTmUZBkBa5iciq4rgWNkGJyFcAZBkmRIpMQ2xWAQXAAC4rgxFDuAgIGO5EAJBcQAO4yA0wHcdxCAkIBgIYhgO47gAQDAAGmSTAChgAAArgACAQAFwAAEK4wClcAAgTREAAAEAADAACwAAAIAAYAAAFhAAwAAAYAAwAAP/2Q==',
-    onDelete: onDelete,
     fileUrl:
       'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
-    videoUrl:
-      'https://www.dropbox.com/scl/fi/d37yu43hkis42de1lo0qc/2024-12-22-3.50.43.mp4?rlkey=wp59xi712h86mo7p4gfsopp4l&st=x4smbpr9&dl=1',
   },
 }
 
@@ -40,12 +38,12 @@ export const LongTitle: Story = {
     presenter: '주영준',
     id: '2',
     likeCount: 0,
+    showMessage: () => {
+      console.log('삭제되었습니다.')
+    },
     thumbnail:
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ9bfSaoPCshv-N6GeH30uUuosNsaAUrulPvA&s',
-    onDelete: onDelete,
     fileUrl:
       'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
-    videoUrl:
-      'https://www.dropbox.com/scl/fi/d37yu43hkis42de1lo0qc/2024-12-22-3.50.43.mp4?rlkey=wp59xi712h86mo7p4gfsopp4l&st=x4smbpr9&dl=1',
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,6 +6564,11 @@ react-icons@^5.3.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
   integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
 
+react-intersection-observer@^9.15.1:
+  version "9.15.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz#5866b6fdfef24be9f288b74b35b773f63d90c3eb"
+  integrity sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 요약
- 세션 페이지  react-query로 api 연동 
- 세션페이지 기능 구현
- 세션페이지 react-query와 react-intersection-observer로 무한스크롤 구현
- 필터버튼 삭제 구현
- editSession 코드 리팩토링
- 블로그 페이지 api 연동 (최신화된 부분 다음 브랜치에서 할 예정)
-  

<br><br>

## 참고 사항
api 최신화 된 부분은 다음 브랜치에서 할 예정
- 세션 페이지에서 401 뜨는 에러 
- 블로그 최신화된 api 연동
<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
