### PR TITLE
fix, feat, design: 캘린더 관련 건의 사항 수정

### DIFF
--- a/src/api/calendar/deleteEvent.ts
+++ b/src/api/calendar/deleteEvent.ts
@@ -4,6 +4,7 @@ const deleteEvent = async (eventId: number) => {
   const response = await fetch(`/api/v1/events/${eventId}`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/src/api/calendar/getCurrentUser.ts
+++ b/src/api/calendar/getCurrentUser.ts
@@ -1,0 +1,12 @@
+export default async function getCurrentUser() {
+  const res = await fetch('/api/v1/users', {
+    method: 'GET',
+    credentials: 'include', //사용자 식별, 로그인 확인
+  })
+
+  if (!res.ok) {
+    throw new Error('사용자 정보를 불러오는 데 실패했습니다.')
+  }
+
+  return res.json()
+}

--- a/src/api/calendar/patchEvent.ts
+++ b/src/api/calendar/patchEvent.ts
@@ -9,6 +9,7 @@ const patchEvent = async (
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(eventData),
+    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/src/api/calendar/postEvent.ts
+++ b/src/api/calendar/postEvent.ts
@@ -13,6 +13,7 @@ const postEvent = async (eventData: EventData): Promise<void> => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(eventData),
+    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/src/components/calender/Calendar.tsx
+++ b/src/components/calender/Calendar.tsx
@@ -109,8 +109,7 @@ export default function Calendar({
 
       daysArray.push(
         <div key={i} className="w-[138px] min-h-[183px] border-t-2">
-          <button
-            type="button"
+          <div
             className={`w-full h-full text-2xl font-bold p-3 cursor-pointer hover:bg-lightgray/50 flex flex-col items-start ${
               isToday ? 'border-primary bg-lightgray/30' : ''
             }`}
@@ -142,7 +141,7 @@ export default function Calendar({
                 )
               })}
             </div>
-          </button>
+          </div>
         </div>,
       )
     }

--- a/src/components/calender/Calendar.tsx
+++ b/src/components/calender/Calendar.tsx
@@ -11,38 +11,22 @@ import BookmarkModal from '../common/BookmarkModal'
 interface CalendarProps {
   selectedCategories: string[]
   setAuthModalOpen: () => void
+  currentUserId: number | null
 }
 
 export default function Calendar({
   selectedCategories,
   setAuthModalOpen,
+  currentUserId,
 }: CalendarProps) {
   const [currentDate, setCurrentDate] = useState(dayjs())
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null)
 
   const daysOfWeek = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
   const startOfMonth = currentDate.startOf('month').day()
   const daysInMonth = currentDate.daysInMonth()
   const currentMonth = currentDate.month() + 1 // month는 0부터 시작하므로 1을 더함
   const today = dayjs()
-
-  useEffect(() => {
-    const fetchMe = async () => {
-      try {
-        const res = await fetch('/api/v1/users', {
-          method: 'GET',
-          credentials: 'include',
-        })
-        if (!res.ok) return
-        const user = await res.json()
-        setCurrentUserId(user.id)
-      } catch (err) {
-        console.error('유저 정보 가져오기 실패', err)
-      }
-    }
-    fetchMe()
-  }, [])
 
   const { data: events } = useGetEvents({
     category: selectedCategories.length > 0 ? selectedCategories : undefined,
@@ -188,7 +172,7 @@ export default function Calendar({
       {/* 일 */}
       <div className="grid grid-cols-7 gap-7">{renderDays()}</div>
 
-      {selectedDate && currentUserId !== null && (
+      {selectedDate && typeof currentUserId === 'number' && (
         <EventsDetailModal
           date={dayjs(selectedDate).format('MM.DD')}
           events={eventsForSelectedDate}

--- a/src/components/calender/CalendarClient.tsx
+++ b/src/components/calender/CalendarClient.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { CalendarClientProps } from '@/types/calendar'
-import { User } from '@/components/calender/CalendarEventCard'
 import AddCalendarBtn from '@/components/calender/AddCalendarBtn'
 import AddCalenderModal from '@/components/calender/AddCalendarModal'
 import Calendar from '@/components/calender/Calendar'
 import FilterBtn from '@/components/calender/FilterBtn'
 import AuthModal from '@/components/common/AuthModal'
 import BookmarkModal from '@/components/common/BookmarkModal'
+import getCurrentUser from '@/api/calendar/getCurrentUser'
 
 export default function CalendarClient({
   CATEGORIES,
@@ -18,28 +18,28 @@ export default function CalendarClient({
   const [selectedCategories, setSelectedCategories] = useState(['ALL'])
   const [authModalOpen, setAuthModalOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
-  const [currentUser, setCurrentUser] = useState<User | null>(null)
+  const [currentUserId, setCurrentUserId] = useState<number | null>(null)
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const user = await getCurrentUser()
+        setCurrentUserId(user.id)
+      } catch {}
+    }
+    fetchUser()
+  }, [])
 
   const handleOpenModal = async () => {
-    if (!currentUser) {
+    if (!currentUserId) {
       try {
-        const response = await fetch('/api/v1/users', {
-          method: 'GET',
-          credentials: 'include',
-        })
-        if (response.status === 401) {
-          setAuthModalOpen(true)
-          return
-        }
-        if (!response.ok) throw new Error()
-        const user = await response.json()
-        setCurrentUser(user)
+        const user = await getCurrentUser()
+        setCurrentUserId(user.id)
       } catch {
         setAuthModalOpen(true)
         return
       }
     }
-
     setShowModal(true)
   }
 
@@ -108,6 +108,7 @@ export default function CalendarClient({
       <Calendar
         selectedCategories={displayCategories}
         setAuthModalOpen={() => setAuthModalOpen(true)}
+        currentUserId={currentUserId}
       />
       {showModal && (
         <AddCalenderModal handleBack={handleCloseModal} mode="create" />

--- a/src/components/calender/CalendarClient.tsx
+++ b/src/components/calender/CalendarClient.tsx
@@ -14,9 +14,7 @@ export default function CalendarClient({
   defaultSelectCategories,
 }: CalendarClientProps) {
   const [showModal, setShowModal] = useState(false)
-  const [selectedCategories, setSelectedCategories] = useState(
-    defaultSelectCategories,
-  )
+  const [selectedCategories, setSelectedCategories] = useState(['ALL'])
   const [authModalOpen, setAuthModalOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
 
@@ -27,17 +25,35 @@ export default function CalendarClient({
   const handleCloseModal = () => setShowModal(false)
 
   const handleFilter = (category: string) => {
+    if (category === 'ALL') {
+      setSelectedCategories(['ALL'])
+      return
+    }
+
     setSelectedCategories((prev) => {
-      if (prev.includes(category)) {
-        const newCategories = prev.filter((cat) => cat !== category)
-        return newCategories.length === 0
-          ? CATEGORIES.map((cat) => cat.value)
-          : newCategories
+      let newSelected
+
+      if (prev.includes('ALL')) {
+        newSelected = [category]
       } else {
-        return [...prev, category]
+        if (prev.includes(category)) {
+          newSelected = prev.filter((cat) => cat !== category)
+        } else {
+          newSelected = [...prev, category]
+        }
       }
+
+      if (newSelected.length === 3) return ['ALL']
+      return newSelected.length === 0 ? ['ALL'] : newSelected
     })
   }
+
+  const allCategoryValues = CATEGORIES.filter((c) => c.value !== 'ALL').map(
+    (c) => c.value,
+  )
+  const displayCategories = selectedCategories.includes('ALL')
+    ? allCategoryValues
+    : selectedCategories
 
   const fetchUserProfile = async () => {
     try {
@@ -89,7 +105,7 @@ export default function CalendarClient({
         {/* <SearchBar placeholder="일정을 검색해보세요." /> */}
       </div>
       <Calendar
-        selectedCategories={selectedCategories}
+        selectedCategories={displayCategories}
         setAuthModalOpen={() => setAuthModalOpen(true)}
       />
       {showModal && (

--- a/src/components/calender/CalendarClient.tsx
+++ b/src/components/calender/CalendarClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { CalendarClientProps } from '@/types/calendar'
+import { User } from '@/components/calender/CalendarEventCard'
 import AddCalendarBtn from '@/components/calender/AddCalendarBtn'
 import AddCalenderModal from '@/components/calender/AddCalendarModal'
 import Calendar from '@/components/calender/Calendar'
@@ -17,9 +18,29 @@ export default function CalendarClient({
   const [selectedCategories, setSelectedCategories] = useState(['ALL'])
   const [authModalOpen, setAuthModalOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const [currentUser, setCurrentUser] = useState<User | null>(null)
 
-  const handleOpenModal = () => {
-    fetchUserProfile()
+  const handleOpenModal = async () => {
+    if (!currentUser) {
+      try {
+        const response = await fetch('/api/v1/users', {
+          method: 'GET',
+          credentials: 'include',
+        })
+        if (response.status === 401) {
+          setAuthModalOpen(true)
+          return
+        }
+        if (!response.ok) throw new Error()
+        const user = await response.json()
+        setCurrentUser(user)
+      } catch {
+        setAuthModalOpen(true)
+        return
+      }
+    }
+
+    setShowModal(true)
   }
 
   const handleCloseModal = () => setShowModal(false)
@@ -54,26 +75,6 @@ export default function CalendarClient({
   const displayCategories = selectedCategories.includes('ALL')
     ? allCategoryValues
     : selectedCategories
-
-  const fetchUserProfile = async () => {
-    try {
-      const response = await fetch('/api/v1/users', {
-        method: 'GET',
-        credentials: 'include',
-      })
-      if (response.status === 401) {
-        setAuthModalOpen(true)
-        return
-      }
-      setShowModal(true)
-      if (!response.ok) {
-        throw new Error('유저조회 실패')
-      }
-    } catch (err: any) {
-      setAuthModalOpen(true)
-      throw new Error(err)
-    }
-  }
 
   return (
     <div className="flex flex-col items-center">

--- a/src/components/calender/CalendarEventCard.tsx
+++ b/src/components/calender/CalendarEventCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 interface User {
+  id: number
   name: string
   nickname: string
   profileImage: string
@@ -73,7 +74,7 @@ export default function CalendarEventCard({
           )}
         </div>
       </button>
-      {mode === 'modal' && (
+      {mode === 'modal' && onEdit && onDelete && (
         <div className="flex gap-3">
           <button onClick={onEdit}>
             <Image src="/pencil.svg" alt="edit" width={15} height={15} />

--- a/src/components/calender/CalendarEventCard.tsx
+++ b/src/components/calender/CalendarEventCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-interface User {
+export interface User {
   id: number
   name: string
   nickname: string

--- a/src/components/calender/EventsDetailModal.tsx
+++ b/src/components/calender/EventsDetailModal.tsx
@@ -5,8 +5,6 @@ import CalendarEventCard, { CalendarEventCardProps } from './CalendarEventCard'
 import { useState, useEffect } from 'react'
 import AddCalendarModal from './AddCalendarModal'
 import EventDeleteModal from './EventDeleteModal'
-import getCurrentUser from '@/api/calendar/getCurrentUser'
-// import BookmarkModal from '../common/BookmarkModal'
 
 interface EventsDetailModalProps {
   date: string
@@ -19,23 +17,11 @@ export default function EventsDetailModal({
   date,
   events,
   onClose,
+  currentUserId,
 }: EventsDetailModalProps) {
   const [editEventId, setEditEventId] = useState<number | null>(null)
   const [deleteEventId, setDeleteEventId] = useState<number | null>(null)
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null)
 
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const user = await getCurrentUser()
-        setCurrentUserId(user.id)
-      } catch (err) {
-        console.error('유저 정보를 불러오지 못했습니다: ', err)
-      }
-    }
-    fetchUser()
-  }, [])
-  // const [modalOpen, setModalOpen] = useState(false)
   const handleEdit = (eventId: number) => {
     setEditEventId(eventId)
   }

--- a/src/components/calender/FilterBtn.tsx
+++ b/src/components/calender/FilterBtn.tsx
@@ -5,13 +5,24 @@ interface FilterBtnProps {
   isClicked?: boolean
   onClick: () => void
 }
-export default function FilterBtn({ title, isClicked, onClick }: FilterBtnProps) {
+
+export default function FilterBtn({
+  title,
+  isClicked,
+  onClick,
+}: FilterBtnProps) {
   return (
     <button
       type="button"
-      className={`h-8 px-6 border rounded-2xl text-lg ${!isClicked ? 'text-gray bg-lightgray/50 border-gray' : 'text-[#DD7E3A] bg-[#FFF6F0] border-primary'}`}
       onClick={onClick}
->
+      className={`h-8 px-6 border rounded-2xl text-lg transition-colors duration-200
+        ${
+          !isClicked
+            ? 'text-gray bg-lightgray/50 border-gray'
+            : 'text-[#DD7E3A] bg-[#FFF6F0] border-primary'
+        }
+      `}
+    >
       {title}
     </button>
   )

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,5 +1,6 @@
 export const CATEGORIES = [
-    { title: '행사', value: 'TECHEER' },
-    { title: '컨퍼런스', value: 'CONFERENCE' },
-    { title: '지원 공고', value: 'JOBINFO' },
-  ]
+  { title: '전체', value: 'ALL' },
+  { title: '행사', value: 'TECHEER' },
+  { title: '컨퍼런스', value: 'CONFERENCE' },
+  { title: '지원 공고', value: 'JOBINFO' },
+]


### PR DESCRIPTION
## 요약

<br>
1. 캘린더에서 본인이 등록한 이벤트만 수정/삭제 버튼 보이게 수정
2. 캘린더에서 버튼을 눌렀을 때 누른 카테고리가 제외되는 것보다 선택되도록 변경
3. 전체 버튼 추가
4. 캘린더에서 일정 추가 버튼 누르면 userAPI 2번 발송 수정
<br>

## 작업 내용

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 캘린더에서 현재 로그인한 사용자의 정보를 불러오고, 해당 사용자의 ID 기반으로 이벤트 수정/삭제 권한을 제어합니다.
    - 카테고리 필터에 '전체' 선택 기능이 추가되어 보다 직관적인 카테고리 선택이 가능합니다.

- **버그 수정**
    - 인증되지 않은 사용자가 모달을 열 때 인증 모달이 표시되어 비정상 접근을 방지합니다.

- **스타일**
    - 필터 버튼에 색상 전환 애니메이션 효과가 추가되었습니다.

- **리팩터**
    - 사용자 정보 및 이벤트 소유자 확인 로직이 간소화되고, 불필요한 네임 기반 비교를 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->