### PR TITLE
fix: 10기 필터 추가

### DIFF
--- a/src/app/(protected)/resume/page.tsx
+++ b/src/app/(protected)/resume/page.tsx
@@ -34,7 +34,7 @@ export default function Resume() {
     'FULL_STACK',
     'DATA_ENGINEER',
   ]
-  const yearOptions = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+  const yearOptions = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
   const category = ['전체', '이력서', '포트폴리오', 'ICT', 'OTHER']
   const sortByOptions = [
     { label: '최신순', value: 'CREATEDAT' },


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #115 

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이력서 페이지의 ‘기수’ 드롭다운에 10기 옵션을 추가했습니다. 이제 1–9에서 1–10으로 선택 범위가 확대되어 더 다양한 기수로 필터링할 수 있습니다. 기존 사용 흐름과 표시 방식은 그대로 유지되며, 성능이나 화면 구성의 변화는 없습니다. 최신 기수 데이터를 포함한 탐색이 한층 편리해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->