### PR TITLE
hotfix: 금주의cs, 블로깅 챌린지 qa 수정사항 반영

### DIFF
--- a/src/api/cs/apis.ts
+++ b/src/api/cs/apis.ts
@@ -74,6 +74,10 @@ export const submitCsAnswer = async (
   })
 
   if (!response.ok) {
+    if (response.status === 400) {
+      const errorData = await response.json()
+      throw new Error(errorData.errors.content)
+    }
     throw new Error('CS 답변 제출에 실패했습니다.')
   }
 }
@@ -113,6 +117,10 @@ export const submitCsComment = async (
   })
 
   if (!response.ok) {
+    if (response.status === 400) {
+      const errorData = await response.json()
+      throw new Error(errorData.errors.content)
+    }
     throw new Error('CS 댓글 작성에 실패했습니다.')
   }
 

--- a/src/api/cs/apis.ts
+++ b/src/api/cs/apis.ts
@@ -51,6 +51,9 @@ export const getCsProblemDetail = async (
   const response = await fetch(`${CS_API_BASE}/problems/${problemId}`)
 
   if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error('존재하지 않는 문제입니다.')
+    }
     throw new Error('CS 문제 상세 정보를 불러오는데 실패했습니다.')
   }
 

--- a/src/components/blog/BlogChallenge.tsx
+++ b/src/components/blog/BlogChallenge.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 'use client'
 
 import Tooltip from './Tip'
@@ -15,16 +14,20 @@ import {
   getBlogChallengeSummaryAPI,
   getBlogChallengeTermsAPI,
   postBlogChallengeAPI,
+  getBlogChallengeAttendanceAPI,
 } from '@/api/blog/blog'
 import { useGetLikesAPI } from '@/api/likes/likes'
 import { useInView } from 'react-intersection-observer'
 import { BlogChallengeProps } from '@/types/blog/BlogProps'
 import { useBlogChallengeState } from '@/hooks/blog/useBlogChallengeState'
+import { useQuery } from '@tanstack/react-query'
+import { useAuthStore } from '@/store/authStore'
 
 const sortOptions = ['최신순', '조회순', '가나다순']
 
 export function BlogChallenge() {
   const queryClient = useQueryClient()
+  const { user } = useAuthStore()
   const {
     terms,
     setTerms,
@@ -48,6 +51,54 @@ export function BlogChallenge() {
   const [isLoading, setIsLoading] = useState(false)
   const { data: likeDate } = useGetLikesAPI('BLOG', 0, 50)
   const [ref, inView] = useInView({ threshold: 0.5 })
+
+  // 현재 사용자의 참여 현황 조회
+  const { data: userProgressList = [] } = useQuery({
+    queryKey: ['attendance', selectedTermId],
+    queryFn: () => getBlogChallengeAttendanceAPI(selectedTermId),
+  })
+
+  // 현재 사용자가 이미 참여 중인지 확인
+  const isAlreadyParticipating = userProgressList.some(
+    (userProgress) => userProgress.userId === user?.id,
+  )
+
+  // 현재 챌린지 기간인지 확인
+  const isCurrentChallengePeriod = () => {
+    const now = new Date()
+    const month = now.getMonth() + 1
+    const currentYear = now.getFullYear()
+
+    let year: number = currentYear
+    let firstHalf: boolean
+
+    if (month >= 3 && month <= 8) {
+      firstHalf = true
+    } else if (month >= 9 && month <= 12) {
+      firstHalf = false
+    } else if (month >= 1 && month <= 2) {
+      year = currentYear - 1
+      firstHalf = false
+    } else {
+      year = currentYear
+      firstHalf = false
+    }
+
+    // 선택된 기간이 현재 챌린지 기간과 일치하는지 확인
+    if (selectedYear.length === 0) return true // 기간이 선택되지 않은 경우 (전체 보기)
+
+    const selectedYearValue = parseInt(selectedYear[0])
+    const selectedTimeValue = timeOptions.find((option) =>
+      selectedTime.includes(option),
+    )
+
+    // 선택된 기간이 현재 챌린지 기간과 일치하는지 확인
+    return (
+      selectedYearValue === year &&
+      ((firstHalf && selectedTimeValue === '상반기') ||
+        (!firstHalf && selectedTimeValue === '하반기'))
+    )
+  }
 
   const resetBlogs = () => {
     setBlogs([])
@@ -231,12 +282,15 @@ export function BlogChallenge() {
             블로깅 챌린지 참여 현황
           </p>
           <div className="flex-1 flex justify-end">
-            <button
-              className="text-lg bg-[#FE9142] text-white px-9 py-1 rounded-xl hover:bg-darkPrimary flex items-center justify-center"
-              onClick={handleApplyClick}
-            >
-              지원하기
-            </button>
+            {/* 현재 챌린지 기간이면서 아직 참여하지 않은 경우에만 버튼 표시 */}
+            {isCurrentChallengePeriod() && !isAlreadyParticipating && (
+              <button
+                className="text-lg bg-[#FE9142] text-white px-9 py-1 rounded-xl hover:bg-darkPrimary flex items-center justify-center"
+                onClick={handleApplyClick}
+              >
+                지원하기
+              </button>
+            )}
           </div>
         </div>
         <ParticipantProgressList selectedTermId={selectedTermId} />

--- a/src/components/cs/CsDetailBox.tsx
+++ b/src/components/cs/CsDetailBox.tsx
@@ -24,7 +24,17 @@ export default function CSDetailBox({ id }: CSDetailBoxProps) {
   }
 
   if (error || !problemDetail) {
-    return <ProblemStatus problemId={Number(id)} updatedAt="" type="error" />
+    // 에러 메시지 추출
+    const errorMessage =
+      error instanceof Error ? error.message : '문제를 불러오는데 실패했습니다.'
+    return (
+      <ProblemStatus
+        problemId={Number(id)}
+        updatedAt=""
+        type="error"
+        message={errorMessage}
+      />
+    )
   }
 
   return (

--- a/src/components/cs/ProblemHeader.tsx
+++ b/src/components/cs/ProblemHeader.tsx
@@ -26,7 +26,10 @@ export default function ProblemHeader({
       <h1 className="text-[2rem] font-bold">
         {isCurrentWeekCS ? '금주의 CS' : '이전 CS'}
       </h1>
-      <p className="text-lg text-gray">{getProblemDate()}</p>
+      {/* 날짜가 있을 때만 표시 */}
+      {getProblemDate() && (
+        <p className="text-lg text-gray">{getProblemDate()}</p>
+      )}
     </div>
   )
 }

--- a/src/components/cs/ProblemStatus.tsx
+++ b/src/components/cs/ProblemStatus.tsx
@@ -25,13 +25,19 @@ export default function ProblemStatus({
       ? 'border border-gray bg-filterbg'
       : 'border border-red-300 bg-red-50'
 
+  // 에러 타입일 때는 message가 있으면 사용하고, 없으면 defaultMessage 사용
+  const displayMessage = type === 'error' && message ? message : defaultMessage
+
   return (
     <div className="max-w-[1200px] mx-auto mt-[3.56rem]">
-      <ProblemHeader problemId={problemId} updatedAt={updatedAt} />
+      {/* updatedAt이 있을 때만 ProblemHeader 표시 */}
+      {updatedAt && (
+        <ProblemHeader problemId={problemId} updatedAt={updatedAt} />
+      )}
       <div
         className={`px-6 py-8 rounded-xl text-xl font-semibold mb-10 ${containerClass}`}
       >
-        <p>{message || defaultMessage}</p>
+        <p>{displayMessage}</p>
       </div>
     </div>
   )

--- a/src/components/cs/SubmittedDetailBox.tsx
+++ b/src/components/cs/SubmittedDetailBox.tsx
@@ -34,7 +34,19 @@ export default function SubmittedDetailBox({ id }: SubmittedDetailBoxProps) {
   }
 
   if (problemError || !problemDetail) {
-    return <ProblemStatus problemId={Number(id)} updatedAt="" type="error" />
+    // 에러 메시지 추출
+    const errorMessage =
+      problemError instanceof Error
+        ? problemError.message
+        : '문제를 불러오는데 실패했습니다.'
+    return (
+      <ProblemStatus
+        problemId={Number(id)}
+        updatedAt=""
+        type="error"
+        message={errorMessage}
+      />
+    )
   }
 
   return (

--- a/src/hooks/cs/useCsDetailBox.ts
+++ b/src/hooks/cs/useCsDetailBox.ts
@@ -45,7 +45,12 @@ export const useCsDetailBox = ({ id }: UseCsDetailBoxProps) => {
       }, 500) // 500ms로 증가
     } catch (error) {
       console.error('답변 제출 실패:', error)
-      alert('답변 제출에 실패했습니다. 다시 시도해주세요.')
+      // 에러 메시지를 alert에 표시
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : '답변 제출에 실패했습니다. 다시 시도해주세요.'
+      alert(errorMessage)
     }
   }
 

--- a/src/hooks/cs/useProblemDate.ts
+++ b/src/hooks/cs/useProblemDate.ts
@@ -7,7 +7,17 @@
  */
 export const useProblemDate = (updatedAt: string) => {
   const getProblemDate = () => {
+    // updatedAt이 빈 문자열이거나 유효하지 않은 경우 빈 문자열 반환
+    if (!updatedAt || updatedAt.trim() === '') {
+      return ''
+    }
+
     const targetDate = new Date(updatedAt)
+
+    // 유효하지 않은 날짜인 경우 빈 문자열 반환
+    if (isNaN(targetDate.getTime())) {
+      return ''
+    }
 
     const year = targetDate.getFullYear()
     const month = targetDate.getMonth() + 1


### PR DESCRIPTION
## 요약
- 삭제된 문제, 미출제, 없는 문제 접근시 - 404예외 처리
- 특정 에러 반환해서 사용자에게 300자 이내 안내를 줄지
- 블로깅챌린지 지원하기 버튼 지원 시 삭제

<br><br>

## 작업 내용
- 없는 문제 상세 페이지에 접근 시 존재하지 않는 문제라는 메시지라는 문구 출력
- 답변, 댓글 작성 시 400에러(300자 초과 에러) 문구로 alert 출력
- 현재 진행중인 챌린지 기간이 아닌 기간 필터링, 이미 참가중일 경우 지원하기 버튼 삭제
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #131 

<br><br>
