### PR TITLE
Hotfix: 금주의 cs 주차 월요일 기준으로 변경

### DIFF
--- a/src/hooks/cs/useProblemDate.ts
+++ b/src/hooks/cs/useProblemDate.ts
@@ -3,7 +3,7 @@
 /**
  * CS 문제의 날짜를 계산하여 주차 정보를 반환하는 훅
  * @param updatedAt 문제의 업데이트 날짜
- * @returns 주차 정보 (예: "2024년 8월 1주차")
+ * @returns 주차 정보 (예: "2024년 9월 1주차")
  */
 export const useProblemDate = (updatedAt: string) => {
   const getProblemDate = () => {
@@ -24,9 +24,11 @@ export const useProblemDate = (updatedAt: string) => {
 
     // 월의 첫 번째 날
     const firstDayOfMonth = new Date(year, month - 1, 1)
-    // 월의 첫 번째 날이 주의 몇 번째 날인지 계산
-    const firstDayWeekday = firstDayOfMonth.getDay()
-    // 해당 날짜가 월의 몇 번째 주인지 계산
+
+    // 월요일을 0, 일요일을 6으로 변환 (getDay()는 일요일이 0)
+    const firstDayWeekday = (firstDayOfMonth.getDay() + 6) % 7
+
+    // 해당 날짜가 월의 몇 번째 주인지 계산 (월요일 기준)
     const weekOfMonth = Math.ceil((targetDate.getDate() + firstDayWeekday) / 7)
 
     return `${year}년 ${month}월 ${weekOfMonth}주차`


### PR DESCRIPTION
## 요약
- 금주의 cs 주차 월요일 기준으로 변경
<br><br>

## 작업 내용
- 금주의 cs 주차 월요일 기준으로 변경
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 연도(기수) 드롭다운 범위를 1–10으로 확장하여 선택 폭을 넓혔습니다.
- Bug Fixes
  - 주차 표기 계산을 월요일 시작 기준으로 변경했습니다.
  - 이에 따라 일부 날짜의 “YYYY년 M월 N주차” 표시가 이전과 달라질 수 있으니 확인해 주세요.
- Documentation
  - 주차 계산 기준(월요일 시작) 관련 설명을 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->