### PR TITLE
[feat] 필터링 유지 url쿼리 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@next/third-parties": "14",
+    "@next/third-parties": "^15.5.2",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/core": "1.9.0",
     "@opentelemetry/sdk-trace-base": "1.9.0",

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -6,16 +6,19 @@ import FilterBtn from '@/components/session/FilterBtn'
 import ProfileList from './@profiletList'
 import SearchBar from '@/components/common/SearchBar'
 import ProfileCard from '@/components/profile/ProfileCard'
+import { useUrlQueryFilters } from '@/hooks/useUrlQueryFilters'
 
 export default function Page() {
   // 검색어 상태 추가
   const [searchResults, setSearchResults] = useState<any>(null)
-
-  const [selectedPosition, setSelectedPosition] = useState<string[]>([])
-  const [selectedYear, setSelectedYear] = useState<string[]>([])
-  const [selectedUniversity, setSelectedUniversity] = useState<string[]>([])
-  const [selectedGrade, setSelectedGrade] = useState<string[]>([])
-  const [selectedSortBy, setSelectedSortBy] = useState<string[]>(['기수순'])
+  const { filters, set, remove } = useUrlQueryFilters()
+  const {
+    selectedPosition,
+    selectedYear,
+    selectedUniversity,
+    selectedGrade,
+    selectedSortBy,
+  } = filters
 
   const positionOptions = [
     'FRONTEND',
@@ -61,18 +64,17 @@ export default function Page() {
   //기수 탭
   // const category = ['전체', '이력서', '포트폴리오', 'ICT', 'OTHER']
 
-  const handleRemoveFilter = (filter: string | number, type: string) => {
-    if (type === 'position') {
-      setSelectedPosition(selectedPosition.filter((item) => item !== filter))
-    } else if (type === 'year') {
-      setSelectedYear(selectedYear.filter((item) => item !== filter))
-    } else if (type === 'university') {
-      setSelectedUniversity(
-        selectedUniversity.filter((item) => item !== filter),
-      )
-    } else if (type === 'grade') {
-      setSelectedGrade(selectedGrade.filter((item) => item !== filter))
-    }
+  const handleRemoveFilter = (
+    filter: string | number,
+    type: 'position' | 'year' | 'university' | 'grade',
+  ) => {
+    const map = {
+      position: 'selectedPosition',
+      year: 'selectedYear',
+      university: 'selectedUniversity',
+      grade: 'selectedGrade',
+    } as const
+    remove(map[type], String(filter))
   }
 
   return (
@@ -101,32 +103,32 @@ export default function Page() {
               title="포지션"
               options={positionOptions}
               selectedOptions={selectedPosition}
-              setSelectedOptions={setSelectedPosition}
+              setSelectedOptions={(v) => set('selectedPosition', v)}
             />
             <Dropdown
               title="기수"
               options={yearOptions} // Dropdown 컴포넌트에서 문자열로 처리
-              selectedOptions={selectedYear.map(String)} // 숫자를 문자열로 변환
-              setSelectedOptions={setSelectedYear}
+              selectedOptions={selectedYear}
+              setSelectedOptions={(v) => set('selectedYear', v)}
             />
             <Dropdown
               title="대학"
               options={universityOptions}
               selectedOptions={selectedUniversity}
-              setSelectedOptions={setSelectedUniversity}
+              setSelectedOptions={(v) => set('selectedUniversity', v)}
             />
             <Dropdown
               title="학년"
               options={gradeOptions}
               selectedOptions={selectedGrade}
-              setSelectedOptions={setSelectedGrade}
+              setSelectedOptions={(v) => set('selectedGrade', v)}
             />
           </div>
           <Dropdown
             title={selectedSortBy[0] || '기수순'}
             options={sortByOptions}
             selectedOptions={selectedSortBy}
-            setSelectedOptions={setSelectedSortBy}
+            setSelectedOptions={(v) => set('selectedSortBy', v)}
             singleSelect={true}
           />
         </div>

--- a/src/app/(protected)/resume/page.tsx
+++ b/src/app/(protected)/resume/page.tsx
@@ -11,6 +11,7 @@ import ResumeList from './@resumeList'
 import ResumeFolder from '@/components/resume/ResumeFolder'
 import SearchBar from '@/components/common/SearchBar'
 import { useTapBarStore } from '@/store/tapBarStore'
+import { useUrlQueryFilters } from '@/hooks/useUrlQueryFilters'
 
 export default function Resume() {
   const router = useRouter() // Resume 페이지에서 useRouter 사용
@@ -21,9 +22,9 @@ export default function Resume() {
   // 검색어 상태 추가
   const [searchResults, setSearchResults] = useState<any>(null)
 
-  // 드롭다운 선택된 옵션 상태 관리
-  const [selectedPosition, setSelectedPosition] = useState<string[]>([])
-  const [selectedYear, setSelectedYear] = useState<string[]>([])
+  // 드롭다운 선택된 옵션 상태 관리 (URL 동기화)
+  const { filters, set, remove } = useUrlQueryFilters()
+  const { selectedPosition, selectedYear } = filters
   const [selectedCategory, setSelectedCategory] = useState('전체')
   const [selectedSortBy, setSelectedSortBy] = useState<string>('CREATEDAT')
 
@@ -45,9 +46,9 @@ export default function Resume() {
   //필터 제거
   const handleRemoveFilter = (filter: string | number, type: string) => {
     if (type === 'position') {
-      setSelectedPosition(selectedPosition.filter((item) => item !== filter))
+      remove('selectedPosition', String(filter))
     } else if (type === 'year') {
-      setSelectedYear(selectedYear.filter((item) => item !== filter))
+      remove('selectedYear', String(filter))
     }
   }
   const { activeOption } = useTapBarStore()
@@ -97,13 +98,13 @@ export default function Resume() {
             title="포지션"
             options={positionOptions}
             selectedOptions={selectedPosition}
-            setSelectedOptions={setSelectedPosition}
+            setSelectedOptions={(v) => set('selectedPosition', v)}
           />
           <Dropdown
             title="기수"
             options={yearOptions} // Dropdown 컴포넌트에서 문자열로 처리
-            selectedOptions={selectedYear.map(String)} // 숫자를 문자열로 변환
-            setSelectedOptions={setSelectedYear}
+            selectedOptions={selectedYear}
+            setSelectedOptions={(v) => set('selectedYear', v)}
           />
           <Dropdown
             title={

--- a/src/components/project/TeamsPage.tsx
+++ b/src/components/project/TeamsPage.tsx
@@ -27,12 +27,14 @@ import ProjectCard from '@/components/project/ProjectCard'
 import StudyCard from '@/components/project/StudyCard'
 import SkeletonProjectCard from '@/components/project/SkeletonProjectCard'
 import AddBtn from '@/components/project/add/AddBtn'
+import { useUrlQueryFilters } from '@/hooks/useUrlQueryFilters'
 
 export default function TeamsPage() {
   const { activeOption } = useTapBarStore()
-  const [selectedRecruitment, setSelectedRecruitment] = useState<string[]>([])
-  const [selectedProgress, setSelectedProgress] = useState<string[]>([])
-  const [selectedPosition, setSelectedPosition] = useState<string[]>([])
+  const { filters, set, remove } = useUrlQueryFilters()
+  const selectedRecruitment = filters.selectedRecruitment ?? []
+  const selectedProgress = filters.selectedProgress ?? []
+  const selectedPosition = filters.selectedPosition
   const [selectedSort, setSelectedSort] = useState<string[]>(['최신순']) // 기본값 필수
   const [searchResults, setSearchResults] = useState<any>(null)
 
@@ -64,38 +66,38 @@ export default function TeamsPage() {
     setSelectedSort(newSelectedSort)
   }
 
-  // 필터 조립
-  const filters: TeamFilter = {}
+  // 팀 조회용 쿼리 조립 (hook의 filters와 이름 충돌 방지)
+  const query: TeamFilter = {}
 
   // 안전한 activeOption 처리
   const safeActiveOption = activeOption || '전체보기'
 
   if (safeActiveOption !== '전체보기') {
     if (safeActiveOption === '프로젝트') {
-      filters.teamTypes = ['PROJECT']
+      query.teamTypes = ['PROJECT']
     } else if (safeActiveOption === '스터디') {
-      filters.teamTypes = ['STUDY']
+      query.teamTypes = ['STUDY']
     }
   }
   if (selectedRecruitment.length === 1) {
-    filters.isRecruited = selectedRecruitment[0] === '모집 중'
+    query.isRecruited = selectedRecruitment[0] === '모집 중'
   }
   if (selectedProgress.length === 1) {
-    filters.isFinished = selectedProgress[0] === '진행 완료'
+    query.isFinished = selectedProgress[0] === '진행 완료'
   }
   if (
     (safeActiveOption === '프로젝트' || safeActiveOption === '전체보기') &&
     selectedPosition.length > 0
   ) {
-    filters.positions = selectedPosition as any
+    query.positions = selectedPosition
   }
 
   // 정렬 옵션 추가 (항상 적용됨)
-  filters.sortType = getSortType(selectedSort[0])
+  query.sortType = getSortType(selectedSort[0])
 
   // 무한스크롤 데이터 조회
   const { teams, isLoading, isLoadingMore, error, hasNext, loadMoreRef } =
-    useTeamsList(filters)
+    useTeamsList(query)
 
   // 필터 제거 (정렬 제외)
   const removeFilter = (
@@ -103,11 +105,11 @@ export default function TeamsPage() {
     type: 'recruitment' | 'progress' | 'position',
   ) => {
     if (type === 'recruitment') {
-      setSelectedRecruitment((rs) => rs.filter((r) => r !== item))
+      remove('selectedRecruitment', item)
     } else if (type === 'progress') {
-      setSelectedProgress((ps) => ps.filter((p) => p !== item))
+      remove('selectedProgress', item)
     } else if (type === 'position') {
-      setSelectedPosition((ps) => ps.filter((p) => p !== item))
+      remove('selectedPosition', item)
     }
   }
 
@@ -167,14 +169,14 @@ export default function TeamsPage() {
             title="모집여부"
             options={RECRUITMENT_OPTIONS}
             selectedOptions={selectedRecruitment}
-            setSelectedOptions={setSelectedRecruitment}
+            setSelectedOptions={(v) => set('selectedRecruitment', v)}
             singleSelect={true}
           />
           <Dropdown
             title="진행여부"
             options={PROGRESS_OPTIONS}
             selectedOptions={selectedProgress}
-            setSelectedOptions={setSelectedProgress}
+            setSelectedOptions={(v) => set('selectedProgress', v)}
             singleSelect={true}
           />
           {safeActiveOption === '프로젝트' && (
@@ -182,7 +184,7 @@ export default function TeamsPage() {
               title="포지션"
               options={POSITION_OPTIONS}
               selectedOptions={selectedPosition}
-              setSelectedOptions={setSelectedPosition}
+              setSelectedOptions={(v) => set('selectedPosition', v)}
             />
           )}
         </div>

--- a/src/components/project/TeamsPage.tsx
+++ b/src/components/project/TeamsPage.tsx
@@ -34,7 +34,7 @@ export default function TeamsPage() {
   const { filters, set, remove } = useUrlQueryFilters()
   const selectedRecruitment = filters.selectedRecruitment ?? []
   const selectedProgress = filters.selectedProgress ?? []
-  const selectedPosition = filters.selectedPosition
+  const selectedPosition = filters.selectedPosition ?? []
   const [selectedSort, setSelectedSort] = useState<string[]>(['최신순']) // 기본값 필수
   const [searchResults, setSearchResults] = useState<any>(null)
 

--- a/src/hooks/useUrlQueryFilters.ts
+++ b/src/hooks/useUrlQueryFilters.ts
@@ -59,9 +59,9 @@ function mergeParams(base: URLSearchParams, filters: Filters): URLSearchParams {
   Object.values(MAP).forEach((k) => next.delete(k))
 
   const addAll = (key: string, values: string[]) => {
-    // 중복 제거 + 캐논 정렬로 네비게이션 불필요 호출 방지
+    // 중복 제거 + 캐논 정렬(로케일 기준)로 네비게이션 불필요 호출 방지
     const uniq = Array.from(new Set(values.filter(Boolean)))
-    const canon = uniq.slice().sort()
+    const canon = uniq.slice().sort((a, b) => a.localeCompare(b, 'ko'))
     canon.forEach((v) => next.append(key, v))
   }
 

--- a/src/hooks/useUrlQueryFilters.ts
+++ b/src/hooks/useUrlQueryFilters.ts
@@ -9,6 +9,8 @@ export type Filters = {
   selectedUniversity: string[]
   selectedGrade: string[]
   selectedSortBy: string[]
+  selectedRecruitment?: string[]
+  selectedProgress?: string[]
 }
 
 const DEFAULTS: Filters = {
@@ -17,6 +19,8 @@ const DEFAULTS: Filters = {
   selectedUniversity: [],
   selectedGrade: [],
   selectedSortBy: ['기수순'],
+  selectedRecruitment: [],
+  selectedProgress: [],
 }
 
 const MAP = {
@@ -25,6 +29,8 @@ const MAP = {
   selectedUniversity: 'university',
   selectedGrade: 'grade',
   selectedSortBy: 'sortBy',
+  selectedRecruitment: 'recruitment',
+  selectedProgress: 'progress',
 } as const satisfies Record<keyof Filters, string>
 
 function parseFromParams(params: URLSearchParams): Filters {
@@ -36,6 +42,8 @@ function parseFromParams(params: URLSearchParams): Filters {
     selectedUniversity: toArr(MAP.selectedUniversity),
     selectedGrade: toArr(MAP.selectedGrade),
     selectedSortBy: toArr(MAP.selectedSortBy),
+    selectedRecruitment: toArr(MAP.selectedRecruitment),
+    selectedProgress: toArr(MAP.selectedProgress),
   }
 
   if (parsed.selectedSortBy.length === 0) {
@@ -68,6 +76,12 @@ function mergeParams(base: URLSearchParams, filters: Filters): URLSearchParams {
   }
   if (filters.selectedGrade.length > 0) {
     addAll(MAP.selectedGrade, filters.selectedGrade)
+  }
+  if (filters.selectedRecruitment && filters.selectedRecruitment.length > 0) {
+    addAll(MAP.selectedRecruitment, filters.selectedRecruitment)
+  }
+  if (filters.selectedProgress && filters.selectedProgress.length > 0) {
+    addAll(MAP.selectedProgress, filters.selectedProgress)
   }
   if (filters.selectedSortBy.length > 0) {
     const pick = filters.selectedSortBy[0]

--- a/src/hooks/useUrlQueryFilters.ts
+++ b/src/hooks/useUrlQueryFilters.ts
@@ -9,8 +9,8 @@ export type Filters = {
   selectedUniversity: string[]
   selectedGrade: string[]
   selectedSortBy: string[]
-  selectedRecruitment?: string[]
-  selectedProgress?: string[]
+  selectedRecruitment: string[]
+  selectedProgress: string[]
 }
 
 const DEFAULTS: Filters = {
@@ -59,9 +59,13 @@ function mergeParams(base: URLSearchParams, filters: Filters): URLSearchParams {
   Object.values(MAP).forEach((k) => next.delete(k))
 
   const addAll = (key: string, values: string[]) => {
-    // 중복 제거 + 캐논 정렬(로케일 기준)로 네비게이션 불필요 호출 방지
+    // 중복 제거 + 결정적 정렬(localeCompare with numeric)
     const uniq = Array.from(new Set(values.filter(Boolean)))
-    const canon = uniq.slice().sort((a, b) => a.localeCompare(b, 'ko'))
+    const canon = uniq
+      .slice()
+      .sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+      )
     canon.forEach((v) => next.append(key, v))
   }
 
@@ -142,7 +146,7 @@ export function useUrlQueryFilters() {
     (name: K, value: string, nav: 'replace' | 'push' = 'replace') => {
       const arr = new Set((filters[name] as string[]) ?? [])
       arr.add(value)
-      set(name, Array.from(arr) as Filters[K], nav)
+      set(name, Array.from(arr), nav)
     },
     [filters, set],
   )
@@ -150,7 +154,7 @@ export function useUrlQueryFilters() {
   const remove = useCallback(
     (name: K, value: string, nav: 'replace' | 'push' = 'replace') => {
       const arr = ((filters[name] as string[]) ?? []).filter((v) => v !== value)
-      set(name, arr as Filters[K], nav)
+      set(name, arr, nav)
     },
     [filters, set],
   )

--- a/src/hooks/useUrlQueryFilters.ts
+++ b/src/hooks/useUrlQueryFilters.ts
@@ -1,0 +1,160 @@
+'use client'
+
+import { useMemo, useCallback, useEffect, useRef } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+export type Filters = {
+  selectedPosition: string[]
+  selectedYear: string[]
+  selectedUniversity: string[]
+  selectedGrade: string[]
+  selectedSortBy: string[]
+}
+
+const DEFAULTS: Filters = {
+  selectedPosition: [],
+  selectedYear: [],
+  selectedUniversity: [],
+  selectedGrade: [],
+  selectedSortBy: ['기수순'],
+}
+
+const MAP = {
+  selectedPosition: 'position',
+  selectedYear: 'year',
+  selectedUniversity: 'university',
+  selectedGrade: 'grade',
+  selectedSortBy: 'sortBy',
+} as const satisfies Record<keyof Filters, string>
+
+function parseFromParams(params: URLSearchParams): Filters {
+  const toArr = (key: string) => params.getAll(key).filter(Boolean)
+
+  const parsed: Filters = {
+    selectedPosition: toArr(MAP.selectedPosition),
+    selectedYear: toArr(MAP.selectedYear),
+    selectedUniversity: toArr(MAP.selectedUniversity),
+    selectedGrade: toArr(MAP.selectedGrade),
+    selectedSortBy: toArr(MAP.selectedSortBy),
+  }
+
+  if (parsed.selectedSortBy.length === 0) {
+    parsed.selectedSortBy = [...DEFAULTS.selectedSortBy]
+  }
+
+  return parsed
+}
+
+function mergeParams(base: URLSearchParams, filters: Filters): URLSearchParams {
+  const next = new URLSearchParams(base.toString())
+
+  Object.values(MAP).forEach((k) => next.delete(k))
+
+  const addAll = (key: string, values: string[]) => {
+    // 중복 제거 + 캐논 정렬로 네비게이션 불필요 호출 방지
+    const uniq = Array.from(new Set(values.filter(Boolean)))
+    const canon = uniq.slice().sort()
+    canon.forEach((v) => next.append(key, v))
+  }
+
+  if (filters.selectedPosition.length > 0) {
+    addAll(MAP.selectedPosition, filters.selectedPosition)
+  }
+  if (filters.selectedYear.length > 0) {
+    addAll(MAP.selectedYear, filters.selectedYear)
+  }
+  if (filters.selectedUniversity.length > 0) {
+    addAll(MAP.selectedUniversity, filters.selectedUniversity)
+  }
+  if (filters.selectedGrade.length > 0) {
+    addAll(MAP.selectedGrade, filters.selectedGrade)
+  }
+  if (filters.selectedSortBy.length > 0) {
+    const pick = filters.selectedSortBy[0]
+    if (pick !== DEFAULTS.selectedSortBy[0])
+      next.append(MAP.selectedSortBy, pick)
+  }
+
+  return next
+}
+
+export function useUrlQueryFilters() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const filters = useMemo<Filters>(() => {
+    const params = new URLSearchParams(searchParams?.toString())
+    return parseFromParams(params)
+  }, [searchParams])
+
+  const timerRef = useRef<number | null>(null)
+  const pendingRef = useRef<URLSearchParams | null>(null)
+
+  const commit = useCallback(
+    (nextParams: URLSearchParams, mode: 'replace' | 'push' = 'replace') => {
+      const current = searchParams?.toString() ?? ''
+      const next = nextParams.toString()
+      if (current === next) return
+
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current)
+      }
+      pendingRef.current = nextParams
+      timerRef.current = window.setTimeout(() => {
+        const q = pendingRef.current?.toString()
+        const url = q && q.length > 0 ? `${pathname}?${q}` : pathname
+        if (mode === 'push') router.push(url, { scroll: false })
+        else router.replace(url, { scroll: false })
+        pendingRef.current = null
+        timerRef.current = null
+      }, 0)
+    },
+    [pathname, router, searchParams],
+  )
+
+  type K = keyof Filters
+  const set = useCallback(
+    (name: K, value: Filters[K], nav: 'replace' | 'push' = 'replace') => {
+      const current = new URLSearchParams(searchParams?.toString())
+      const nextFilters: Filters = { ...filters, [name]: value }
+      const merged = mergeParams(current, nextFilters)
+      commit(merged, nav)
+    },
+    [filters, searchParams, commit],
+  )
+
+  const add = useCallback(
+    (name: K, value: string, nav: 'replace' | 'push' = 'replace') => {
+      const arr = new Set((filters[name] as string[]) ?? [])
+      arr.add(value)
+      set(name, Array.from(arr) as Filters[K], nav)
+    },
+    [filters, set],
+  )
+
+  const remove = useCallback(
+    (name: K, value: string, nav: 'replace' | 'push' = 'replace') => {
+      const arr = ((filters[name] as string[]) ?? []).filter((v) => v !== value)
+      set(name, arr as Filters[K], nav)
+    },
+    [filters, set],
+  )
+
+  const clear = useCallback(
+    (nav: 'replace' | 'push' = 'replace') => {
+      const current = new URLSearchParams(searchParams?.toString())
+      const merged = mergeParams(current, DEFAULTS)
+      commit(merged, nav)
+    },
+    [searchParams, commit],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return { filters, set, add, remove, clear, router }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,10 +1590,10 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz#ed199a920efb510cfe941cd75ed38a7be21e756f"
   integrity sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==
 
-"@next/third-parties@14":
-  version "14.2.32"
-  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-14.2.32.tgz#50c70f02149ab45787c19e6147014af18c525bfb"
-  integrity sha512-11I+hStPj41OLUew6pXAvSX6aUGF7vN1Ie8072o3jSA3wQC1hjwkcL/pKiIGe6eVkymBLxG/cSkyQOs+NQ2tLg==
+"@next/third-parties@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-15.5.2.tgz#0fa9b96f5aa71386275ef45b4dc06870de22926c"
+  integrity sha512-WkAP39cP5FMqrIq6CjnsTGO7A49Acliqmu1TytWMCOoCv57MN25a0+htKE5VRwm9vzAwSXKHSNnRso6nKLrKKg==
   dependencies:
     third-party-capital "1.0.20"
 
@@ -6760,18 +6760,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lottie-react/-/lottie-react-2.4.1.tgz#4bd3f2a8a5e48edbd43c05ca5080fdd50f049d31"
-  integrity sha512-LQrH7jlkigIIv++wIyrOYFLHSKQpEY4zehPicL9bQsrt1rnoKRYCYgpCUe5maqylNtacy58/sQDZTkwMcTRxZw==
-  dependencies:
-    lottie-web "^5.10.2"
-
-lottie-web@^5.10.2, lottie-web@^5.12.2:
-  version "5.12.2"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.12.2.tgz#579ca9fe6d3fd9e352571edd3c0be162492f68e5"
-  integrity sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==
-
 loupe@^3.1.0, loupe@^3.1.1, loupe@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
@@ -8012,15 +8000,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-lottie-player@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-lottie-player/-/react-lottie-player-2.1.0.tgz#3a3a726d183337197a34c0c0944461ac2469c30c"
-  integrity sha512-rxSNIVVLWYnwzsIow377vZsh7GDbReu70V7IDD9TbbcdcJWons4pSh3nyuEa4QWIZw0ZBIieoZRTsiqnb6MZ3g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    lottie-web "^5.12.2"
-    rfdc "^1.3.0"
-
 react-pdf@*, react-pdf@^9.1.1:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-9.2.1.tgz#35294da1232d310243ffe5e54f39281e6c98d8d4"
@@ -8304,11 +8283,6 @@ reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
-
-rfdc@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
-  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rimraf@^3.0.2:
   version "3.0.2"
@@ -8711,7 +8685,16 @@ string-convert@^0.2.0:
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8811,7 +8794,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9575,7 +9565,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9588,6 +9578,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## 요약

필터링이 초기화되는 문제 해결했습니다




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - URL 기반 다중 필터 관리 도입: 주소창과 필터 동기화로 공유·북마크·뒤로가기 동작 개선, 중복 제거·정렬·초기화 지원.
- 리팩터링
  - 프로필·이력서·팀 목록의 드롭다운 필터 상태를 URL 동기화 방식으로 통합하여 상태 일원화 및 필터 추가/제거 흐름 단순화.
- 작업
  - 외부 의존성 @next/third-parties 버전 범위를 "14"에서 "^15.5.2"로 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->