### PR TITLE
[feat] svg컴포넌트 정상작동

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,23 +14,9 @@ const createRemotePattern = (hostname, pathname = '/**') => ({
 const nextConfig = {
   images: {
     remotePatterns: [
-      // Social platforms
-      createRemotePattern('avatars.slack-edge.com'),
-      createRemotePattern('cdn.discordapp.com'),
-      
-      // Storage buckets
-      createRemotePattern('techeerzip-bucket.s3.ap-southeast-2.amazonaws.com'),
-      createRemotePattern('techeer-bucket.s3.ap-northeast-2.amazonaws.com'),
-      
       // Blog platforms
-      createRemotePattern('images.velog.io'),
       createRemotePattern('miro.medium.com'),
       createRemotePattern('medium.com'),
-      
-      // GitHub
-      createRemotePattern('github.com', '/user-attachments/**'),
-      createRemotePattern('raw.githubusercontent.com'),
-      createRemotePattern('user-images.githubusercontent.com'),
     ],
     // SVG 파일 처리를 위한 설정
     dangerouslyAllowSVG: true,


### PR DESCRIPTION

## 🐛 문제
- 부트캠프 모달에서 SVG 아이콘 렌더링 시 "Element type is invalid" 에러 발생
- GitHub user-attachments 이미지 로딩 실패

## 🔧 해결
- `@svgr/webpack` 패키지 설치
- `next.config.mjs`에 SVG → React 컴포넌트 변환 설정 추가
- GitHub 도메인을 `images.remotePatterns`에 추가

## ✅ 결과
- SVG 컴포넌트 정상 렌더링
- 부트캠프 모달 아이콘 표시 정상화
- 외부 이미지 로딩 문제 해결


## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 출처 지원 범위 확장(예: Medium 등) 및 도메인 패턴 관리 방식 통합
  * SVG를 React 컴포넌트로 직접 사용 가능하도록 SVG 처리 추가

* **기타 개선**
  * 기존 이미지 설정 구조 유지하면서 일부 도메인을 새 관리 방식으로 전환 및 SVG 처리 확장
  * 공개 API 변경 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->