### PR TITLE
feat:부트캠프 현재 기수 불러오는 api 연동

### DIFF
--- a/src/api/bootcamp/getBootcampYear.ts
+++ b/src/api/bootcamp/getBootcampYear.ts
@@ -1,0 +1,12 @@
+export const getBootcampYear = async () => {
+  const res = await fetch('/api/bootcamps/bootcampYear', {
+    method: 'GET',
+    credentials: 'include',
+  })
+
+  if (!res.ok) {
+    throw new Error('부트캠프 기수를 불러오지 못했습니다.')
+  }
+
+  return res.json()
+}

--- a/src/components/bootcamp/main/BootcampHeader.tsx
+++ b/src/components/bootcamp/main/BootcampHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
 import { toogleBootcampParticipation } from '@/api/bootcamp/toogleBootcampParticipation'
+import { getBootcampYear } from '@/api/bootcamp/getBootcampYear'
 
 interface BootcampHeaderProps {
   ModalOpen: () => void
@@ -28,6 +29,12 @@ const BootcampHeader: React.FC<BootcampHeaderProps> = ({ ModalOpen }) => {
         console.error('로컬 유저 파싱 실패', e)
       }
     }
+  }, [])
+
+  useEffect(() => {
+    getBootcampYear().then((res) => {
+      setCurrentBootcampYear(res)
+    })
   }, [])
 
   const participating =


### PR DESCRIPTION
<br><br>

중복된 api요청을 제거하면서, 현재 부트캠프 기수를 불러와 비교하는 로직이 제거되어 문제가 발생

- 중복 api 요청 => 부트캠프 현재 기수 불러오는 api로 수정
- 현재 부트캠프 기수와 자신의 기수를 비교하여 프로젝트 등록 창이 열리도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 부트캠프 연도 데이터를 조회하는 기능이 추가되었습니다.
  * 부트캠프 헤더에서 해당 연도 정보가 자동으로 로드됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->